### PR TITLE
Don't remove the preview directory every time.

### DIFF
--- a/app/back-end/modules/render-html/renderer.js
+++ b/app/back-end/modules/render-html/renderer.js
@@ -248,14 +248,10 @@ class Renderer {
     }
 
     /*
-     * Make the output dir empty before generating the output files
+     * Make sure the output dir exists and is empty before generating the output files
      */
     emptyOutputDir() {
-        if(UtilsHelper.dirExists(this.outputDir)) {
-            fs.removeSync(this.outputDir);
-        }
-
-        fs.mkdirSync(this.outputDir);
+        fs.emptyDirSync(this.outputDir);
     }
 
     /*


### PR DESCRIPTION
Upon preview or site sync, the output directory is emptied instead of being removed and recreated.

Check issue #177 for rationale.