### PR TITLE
Don't compress html when setting is disabled.

### DIFF
--- a/app/back-end/modules/render-html/helpers/template.js
+++ b/app/back-end/modules/render-html/helpers/template.js
@@ -235,7 +235,7 @@ class TemplateHelper {
      * Compress the output HTML if necessary
      */
     compressHTML(content) {
-        if(this.siteConfig.advanced.htmlCompression === 0) {
+        if(!this.siteConfig.advanced.htmlCompression) {
             return content;
         }
 


### PR DESCRIPTION
The "html compression" setting was ignored. This PR fixes it.

See issue #176.