### PR TITLE
character encoding | vs '%7C'  and new line issues with w3 validation

### DIFF
--- a/app/default-files/default-themes/mercury/partials/head.hbs
+++ b/app/default-files/default-themes/mercury/partials/head.hbs
@@ -28,7 +28,7 @@
             {{/if}}
         {{/if}}
         <link rel="preconnect" href="https://fonts.gstatic.com/" crossorigin>
-        <link href="https://fonts.googleapis.com/css?family=Heebo:400,500|Playfair+Display:400" rel="stylesheet"> 
+        <link href="https://fonts.googleapis.com/css?family=Heebo:400,500%7CPlayfair+Display:400" rel="stylesheet"> 
         <link rel="stylesheet" href="{{css "style.css" }}">
 		{{#is "post"}}
            {{#post}}

--- a/app/default-files/default-themes/mercury/partials/share-buttons.hbs
+++ b/app/default-files/default-themes/mercury/partials/share-buttons.hbs
@@ -24,8 +24,7 @@
 {{/if}}
 
 {{#if @config.custom.sharePinterest}}
-<a href="https://pinterest.com/pin/create/button/?url={{encodeUrlFragment url}}&amp;media={{encodeUrlFragment featured_image.url}}
-&amp;description={{encodeUrlFragment title}}" class="js-share pinterest" title="{{ translate 'partials.shareButtons.shareWithPinterest' }}" rel="nofollow">
+<a href="https://pinterest.com/pin/create/button/?url={{encodeUrlFragment url}}&amp;media={{encodeUrlFragment featured_image.url}}&amp;description={{encodeUrlFragment title}}" class="js-share pinterest" title="{{ translate 'partials.shareButtons.shareWithPinterest' }}" rel="nofollow">
     <svg class="icon">
         <use xlink:href="{{@website.assetsUrl}}/svg/svg-map.svg#pinterest" />
     </svg>

--- a/app/default-files/default-themes/portfolio/partials/head.hbs
+++ b/app/default-files/default-themes/portfolio/partials/head.hbs
@@ -28,7 +28,7 @@
             {{/if}}
         {{/if}}       
         <link rel="preconnect" href="https://fonts.gstatic.com/" crossorigin>
-        <link href="https://fonts.googleapis.com/css?family= PT+Serif:400,700|Muli:400,600" rel="stylesheet"> 
+        <link href="https://fonts.googleapis.com/css?family= PT+Serif:400,700%7CMuli:400,600" rel="stylesheet"> 
         {{#is "index"}}
              <link rel="stylesheet" href="{{css "p-slider.css" }}">
         {{/is}}

--- a/app/default-files/default-themes/portfolio/partials/share-buttons.hbs
+++ b/app/default-files/default-themes/portfolio/partials/share-buttons.hbs
@@ -37,8 +37,7 @@
 
 {{#if @config.custom.sharePinterest}}
     <a
-        href="https://pinterest.com/pin/create/button/?url={{encodeUrlFragment url}}&amp;media={{encodeUrlFragment featured_image.url}}
-&amp;description={{encodeUrlFragment title}}"
+        href="https://pinterest.com/pin/create/button/?url={{encodeUrlFragment url}}&amp;media={{encodeUrlFragment featured_image.url}}&amp;description={{encodeUrlFragment title}}"
         class="js-share pinterest"
         title="{{ translate 'partials.shareButtons.shareWithPinterest' }}"
         rel="nofollow">

--- a/app/default-files/default-themes/qf/partials/head.hbs
+++ b/app/default-files/default-themes/qf/partials/head.hbs
@@ -28,7 +28,7 @@
             {{/if}}
         {{/if}}
         <link rel="preconnect" href="https://fonts.gstatic.com/" crossorigin>
-        <link href="https://fonts.googleapis.com/css?family=Arimo:400,700|Playfair+Display:400&amp;subset=latin-ext" rel="stylesheet"> 
+        <link href="https://fonts.googleapis.com/css?family=Arimo:400,700%7CPlayfair+Display:400&amp;subset=latin-ext" rel="stylesheet"> 
         <link rel="stylesheet" href="{{css "style.css" }}"> 
 		{{#is "post"}}
            {{#post}}

--- a/app/default-files/default-themes/qf/partials/share-buttons.hbs
+++ b/app/default-files/default-themes/qf/partials/share-buttons.hbs
@@ -24,8 +24,7 @@
 {{/if}}
 
 {{#if @config.custom.sharePinterest}}
-<a href="https://pinterest.com/pin/create/button/?url={{encodeUrlFragment url}}&amp;media={{encodeUrlFragment featured_image.url}}
-&amp;description={{encodeUrlFragment title}}" class="js-share pinterest" title="{{ translate 'partials.shareButtons.shareWithPinterest' }}" rel="nofollow">
+<a href="https://pinterest.com/pin/create/button/?url={{encodeUrlFragment url}}&amp;media={{encodeUrlFragment featured_image.url}}&amp;description={{encodeUrlFragment title}}" class="js-share pinterest" title="{{ translate 'partials.shareButtons.shareWithPinterest' }}" rel="nofollow">
     <svg class="icon">
         <use xlink:href="{{@website.assetsUrl}}/svg/svg-map.svg#pinterest" />
     </svg>

--- a/app/default-files/default-themes/simple/partials/head.hbs
+++ b/app/default-files/default-themes/simple/partials/head.hbs
@@ -28,7 +28,7 @@
             {{/if}}
         {{/if}}
         <link rel="preconnect" href="https://fonts.gstatic.com/" crossorigin>
-        <link href="https://fonts.googleapis.com/css?family=Roboto:400,700|Roboto+Condensed:400,700&amp;subset=latin-ext" rel="stylesheet">   
+        <link href="https://fonts.googleapis.com/css?family=Roboto:400,700%7CRoboto+Condensed:400,700&amp;subset=latin-ext" rel="stylesheet">   
         <link rel="stylesheet" href="{{css "style.css" }}">
 		{{#is "post"}}
            {{#post}}

--- a/app/default-files/default-themes/simple/partials/share-buttons.hbs
+++ b/app/default-files/default-themes/simple/partials/share-buttons.hbs
@@ -24,8 +24,7 @@
 {{/if}}
 
 {{#if @config.custom.sharePinterest}}
-<a href="https://pinterest.com/pin/create/button/?url={{encodeUrlFragment url}}&amp;media={{encodeUrlFragment featured_image.url}}
-&amp;description={{encodeUrlFragment title}}" class="js-share pinterest" title="{{ translate 'partials.shareButtons.shareWithPinterest' }}" rel="nofollow">
+<a href="https://pinterest.com/pin/create/button/?url={{encodeUrlFragment url}}&amp;media={{encodeUrlFragment featured_image.url}}&amp;description={{encodeUrlFragment title}}" class="js-share pinterest" title="{{ translate 'partials.shareButtons.shareWithPinterest' }}" rel="nofollow">
     <svg class="icon">
         <use xlink:href="{{@website.assetsUrl}}/svg/svg-map.svg#pinterest" />
     </svg>

--- a/app/default-files/default-themes/square/partials/share-buttons.hbs
+++ b/app/default-files/default-themes/square/partials/share-buttons.hbs
@@ -24,8 +24,7 @@
 {{/if}}
 
 {{#if @config.custom.sharePinterest}}
-<a href="https://pinterest.com/pin/create/button/?url={{encodeUrlFragment url}}&amp;media={{encodeUrlFragment featured_image.url}}
-&amp;description={{encodeUrlFragment title}}" class="js-share pinterest" title="{{ translate 'partials.shareButtons.shareWithPinterest' }}" rel="nofollow">
+<a href="https://pinterest.com/pin/create/button/?url={{encodeUrlFragment url}}&amp;media={{encodeUrlFragment featured_image.url}}&amp;description={{encodeUrlFragment title}}" class="js-share pinterest" title="{{ translate 'partials.shareButtons.shareWithPinterest' }}" rel="nofollow">
     <svg>
         <use xlink:href="{{@website.assetsUrl}}/svg/svg-map.svg#pinterest" />
     </svg>

--- a/app/default-files/default-themes/taste/partials/head.hbs
+++ b/app/default-files/default-themes/taste/partials/head.hbs
@@ -31,7 +31,7 @@
             {{/if}}
         {{/if}} 
         <link rel="preconnect" href="https://fonts.gstatic.com/" crossorigin>
-        <link href="https://fonts.googleapis.com/css?family=Nunito:300,600|Montserrat|Damion" rel="stylesheet">       
+        <link href="https://fonts.googleapis.com/css?family=Nunito:300,600%7CMontserrat%7CDamion" rel="stylesheet">       
         <link rel="stylesheet" href="{{css "style.css" }}">       
 		{{#is "post"}}
            {{#post}}

--- a/app/default-files/default-themes/taste/partials/share-buttons.hbs
+++ b/app/default-files/default-themes/taste/partials/share-buttons.hbs
@@ -24,8 +24,7 @@
 {{/if}}
 
 {{#if @config.custom.sharePinterest}}
-<a href="https://pinterest.com/pin/create/button/?url={{encodeUrlFragment url}}&amp;media={{encodeUrlFragment featured_image.url}}
-&amp;description={{encodeUrlFragment title}}" class="js-share pinterest" title="{{ translate 'partials.shareButtons.shareWithPinterest' }}" rel="nofollow">
+<a href="https://pinterest.com/pin/create/button/?url={{encodeUrlFragment url}}&amp;media={{encodeUrlFragment featured_image.url}}&amp;description={{encodeUrlFragment title}}" class="js-share pinterest" title="{{ translate 'partials.shareButtons.shareWithPinterest' }}" rel="nofollow">
     <svg class="icon">
         <use xlink:href="{{@website.assetsUrl}}/svg/svg-map.svg#pinterest" />
     </svg>

--- a/app/default-files/default-themes/tattoo/partials/head.hbs
+++ b/app/default-files/default-themes/tattoo/partials/head.hbs
@@ -28,7 +28,7 @@
             {{/if}}
         {{/if}}
         <link rel="preconnect" href="https://fonts.gstatic.com/" crossorigin>
-        <link href="https://fonts.googleapis.com/css?family=Nunito:400|Yanone+Kaffeesatz:400" rel="stylesheet">     
+        <link href="https://fonts.googleapis.com/css?family=Nunito:400%7CYanone+Kaffeesatz:400" rel="stylesheet">     
         <link rel="stylesheet" href="{{css "style.css" }}">
 		{{#is "post"}}
            {{#post}}

--- a/app/default-files/default-themes/tattoo/partials/share-buttons.hbs
+++ b/app/default-files/default-themes/tattoo/partials/share-buttons.hbs
@@ -24,8 +24,7 @@
 {{/if}}
 
 {{#if @config.custom.sharePinterest}}
-<a href="https://pinterest.com/pin/create/button/?url={{encodeUrlFragment url}}&amp;media={{encodeUrlFragment featured_image.url}}
-&amp;description={{encodeUrlFragment title}}" class="js-share pinterest" title="{{ translate 'partials.shareButtons.shareWithPinterest' }}" rel="nofollow">
+<a href="https://pinterest.com/pin/create/button/?url={{encodeUrlFragment url}}&amp;media={{encodeUrlFragment featured_image.url}}&amp;description={{encodeUrlFragment title}}" class="js-share pinterest" title="{{ translate 'partials.shareButtons.shareWithPinterest' }}" rel="nofollow">
     <svg class="icon">
         <use xlink:href="{{@website.assetsUrl}}/svg/svg-map.svg#pinterest" />
     </svg> Pinterest

--- a/app/default-files/default-themes/technews/partials/share-buttons.hbs
+++ b/app/default-files/default-themes/technews/partials/share-buttons.hbs
@@ -23,8 +23,7 @@
 {{/if}}
 
 {{#if @config.custom.sharePinterest}}
-    <a href="https://pinterest.com/pin/create/button/?url={{encodeUrlFragment url}}&amp;media={{encodeUrlFragment featured_image.url}}
-&amp;description={{encodeUrlFragment title}}" class="js-share pinterest" title="{{ translate 'partials.shareButtons.shareWithPinterest' }}" rel="nofollow">
+    <a href="https://pinterest.com/pin/create/button/?url={{encodeUrlFragment url}}&amp;media={{encodeUrlFragment featured_image.url}}&amp;description={{encodeUrlFragment title}}" class="js-share pinterest" title="{{ translate 'partials.shareButtons.shareWithPinterest' }}" rel="nofollow">
         <svg class="u-icon">
             <use xlink:href="{{@website.assetsUrl}}/svg/svg-map.svg#pinterest" />
         </svg>


### PR DESCRIPTION
See: 
https://validator.w3.org/nu/?doc=https%3A%2F%2Fgetpublii.com%2Fthemes%2Fdemo%2Ftattoo%2F

or: 
https://validator.w3.org/nu/?doc=https%3A%2F%2Fartop.bmth.ac.uk%2Fresources.html

generated with theme tattoo-1.5.9.0 