### PR TITLE
fix amp custom date format display, fix published by missing translation

### DIFF
--- a/app/default-files/default-themes/mercury/amp-post.hbs
+++ b/app/default-files/default-themes/mercury/amp-post.hbs
@@ -52,7 +52,11 @@
                             {{/if}}
                             {{#if @config.post.displayDate}}
                                 <time datetime="{{date createdAt 'YYYY-MM-DDTHH:mm'}}">
-                                    {{date createdAt @config.custom.formatDate}}
+                                    {{#checkIf @config.custom.formatDate '!=' 'custom'}}
+                                        {{date createdAt @config.custom.formatDate}}
+                                    {{else}}
+                                        {{date createdAt @config.custom.formatDateCustom}}
+                                    {{/checkIf}}
                                 </time>
                             {{/if}}
                         </p>

--- a/app/default-files/default-themes/portfolio/amp-post.hbs
+++ b/app/default-files/default-themes/portfolio/amp-post.hbs
@@ -52,7 +52,11 @@
                             {{/if}}
                             {{#if @config.post.displayDate}}
                                 <time datetime="{{date createdAt 'YYYY-MM-DDTHH:mm'}}">
-                                    {{date createdAt @config.custom.formatDate}}
+                                    {{#checkIf @config.custom.formatDate '!=' 'custom'}}
+                                        {{date createdAt @config.custom.formatDate}}
+                                    {{else}}
+                                        {{date createdAt @config.custom.formatDateCustom}}
+                                    {{/checkIf}}
                                 </time>
                             {{/if}}
                         </p>

--- a/app/default-files/default-themes/qf/amp-index.hbs
+++ b/app/default-files/default-themes/qf/amp-index.hbs
@@ -42,10 +42,14 @@
                 
                 <p class="card-meta">                     
                    {{#author}}
-                    by <a href="{{url}}" rel="nofollow" title="{{name}}">{{name}}</a>
+                    {{ translate 'post.publishedBy' }} <a href="{{url}}" rel="nofollow" title="{{name}}">{{name}}</a>
                     {{/author}} 
                     <time datetime="{{date createdAt 'YYYY-MM-DDTHH:mm'}}">
-                        {{date createdAt @config.custom.formatDate}}
+                        {{#checkIf @config.custom.formatDate '!=' 'custom'}}
+                            {{date createdAt @config.custom.formatDate}}
+                        {{else}}
+                            {{date createdAt @config.custom.formatDateCustom}}
+                        {{/checkIf}}
                     </time>
                 </p>
                
@@ -95,10 +99,14 @@
                 
                 <p class="card-meta">                     
                    {{#author}}
-                    by <a href="{{url}}" rel="nofollow" title="{{name}}">{{name}}</a>
+                    {{ translate 'post.publishedBy' }} <a href="{{url}}" rel="nofollow" title="{{name}}">{{name}}</a>
                     {{/author}} 
                     <time datetime="{{date createdAt 'YYYY-MM-DDTHH:mm'}}">
-                        {{date createdAt @config.custom.formatDate}}
+                        {{#checkIf @config.custom.formatDate '!=' 'custom'}}
+                            {{date createdAt @config.custom.formatDate}}
+                        {{else}}
+                            {{date createdAt @config.custom.formatDateCustom}}
+                        {{/checkIf}}
                     </time>
                 </p>
                

--- a/app/default-files/default-themes/qf/amp-post.hbs
+++ b/app/default-files/default-themes/qf/amp-post.hbs
@@ -52,7 +52,11 @@
                             {{/if}}
                             {{#if @config.post.displayDate}}
                                 <time datetime="{{date createdAt 'YYYY-MM-DDTHH:mm'}}">
-                                    {{date createdAt @config.custom.formatDate}}
+                                    {{#checkIf @config.custom.formatDate '!=' 'custom'}}
+                                        {{date createdAt @config.custom.formatDate}}
+                                    {{else}}
+                                        {{date createdAt @config.custom.formatDateCustom}}
+                                    {{/checkIf}}
                                 </time>
                             {{/if}}
                         </p>

--- a/app/default-files/default-themes/simple/amp-post.hbs
+++ b/app/default-files/default-themes/simple/amp-post.hbs
@@ -52,7 +52,11 @@
                             {{/if}}
                             {{#if @config.post.displayDate}}
                                 <time datetime="{{date createdAt 'YYYY-MM-DDTHH:mm'}}">
-                                    {{date createdAt @config.custom.formatDate}}
+                                    {{#checkIf @config.custom.formatDate '!=' 'custom'}}
+                                        {{date createdAt @config.custom.formatDate}}
+                                    {{else}}
+                                        {{date createdAt @config.custom.formatDateCustom}}
+                                    {{/checkIf}}
                                 </time>
                             {{/if}}
                         </p>

--- a/app/default-files/default-themes/square/amp-post.hbs
+++ b/app/default-files/default-themes/square/amp-post.hbs
@@ -52,7 +52,11 @@
                             {{/if}}
                             {{#if @config.post.displayDate}}
                                 <time datetime="{{date createdAt 'YYYY-MM-DDTHH:mm'}}">
-                                    {{date createdAt @config.custom.formatDate}}
+                                    {{#checkIf @config.custom.formatDate '!=' 'custom'}}
+                                        {{date createdAt @config.custom.formatDate}}
+                                    {{else}}
+                                        {{date createdAt @config.custom.formatDateCustom}}
+                                    {{/checkIf}}
                                 </time>
                             {{/if}}
                         </p>

--- a/app/default-files/default-themes/taste/amp-post.hbs
+++ b/app/default-files/default-themes/taste/amp-post.hbs
@@ -52,7 +52,11 @@
                             {{/if}}
                             {{#if @config.post.displayDate}}
                                 <time datetime="{{date createdAt 'YYYY-MM-DDTHH:mm'}}">
-                                    {{date createdAt @config.custom.formatDate}}
+                                    {{#checkIf @config.custom.formatDate '!=' 'custom'}}
+                                        {{date createdAt @config.custom.formatDate}}
+                                    {{else}}
+                                        {{date createdAt @config.custom.formatDateCustom}}
+                                    {{/checkIf}}
                                 </time>
                             {{/if}}
                         </p>

--- a/app/default-files/default-themes/tattoo/amp-post.hbs
+++ b/app/default-files/default-themes/tattoo/amp-post.hbs
@@ -52,7 +52,11 @@
                             {{/if}}
                             {{#if @config.post.displayDate}}
                                 <time datetime="{{date createdAt 'YYYY-MM-DDTHH:mm'}}">
-                                    {{date createdAt @config.custom.formatDate}}
+                                    {{#checkIf @config.custom.formatDate '!=' 'custom'}}
+                                        {{date createdAt @config.custom.formatDate}}
+                                    {{else}}
+                                        {{date createdAt @config.custom.formatDateCustom}}
+                                    {{/checkIf}}
                                 </time>
                             {{/if}}
                         </p>

--- a/app/default-files/default-themes/technews/amp-post.hbs
+++ b/app/default-files/default-themes/technews/amp-post.hbs
@@ -52,7 +52,11 @@
                             {{/if}}
                             {{#if @config.post.displayDate}}
                                 <time datetime="{{date createdAt 'YYYY-MM-DDTHH:mm'}}">
-                                    {{date createdAt @config.custom.formatDate}}
+                                    {{#checkIf @config.custom.formatDate '!=' 'custom'}}
+                                        {{date createdAt @config.custom.formatDate}}
+                                    {{else}}
+                                        {{date createdAt @config.custom.formatDateCustom}}
+                                    {{/checkIf}}
                                 </time>
                             {{/if}}
                         </p>

--- a/app/default-files/theme-files/amp-author.hbs
+++ b/app/default-files/theme-files/amp-author.hbs
@@ -66,7 +66,11 @@
                 
                 <p class="card-meta">                    
                     <time datetime="{{date createdAt 'YYYY-MM-DDTHH:mm'}}">
-                        {{date createdAt @config.custom.formatDate}}
+                        {{#checkIf @config.custom.formatDate '!=' 'custom'}}
+                            {{date createdAt @config.custom.formatDate}}
+                        {{else}}
+                            {{date createdAt @config.custom.formatDateCustom}}
+                        {{/checkIf}}
                     </time>
                 </p>
                

--- a/app/default-files/theme-files/amp-index.hbs
+++ b/app/default-files/theme-files/amp-index.hbs
@@ -42,10 +42,14 @@
                 
                 <p class="card-meta">                     
                    {{#author}}
-                    by <a href="{{url}}" rel="nofollow" title="{{name}}">{{name}}</a>
+                    {{ translate 'post.publishedBy' }} <a href="{{url}}" rel="nofollow" title="{{name}}">{{name}}</a>
                     {{/author}} 
                     <time datetime="{{date createdAt 'YYYY-MM-DDTHH:mm'}}">
-                        {{date createdAt @config.custom.formatDate}}
+                        {{#checkIf @config.custom.formatDate '!=' 'custom'}}
+                            {{date createdAt @config.custom.formatDate}}
+                        {{else}}
+                            {{date createdAt @config.custom.formatDateCustom}}
+                        {{/checkIf}}
                     </time>
                 </p>
                

--- a/app/default-files/theme-files/amp-post.hbs
+++ b/app/default-files/theme-files/amp-post.hbs
@@ -42,10 +42,14 @@
                 <h1> {{title}} </h1>
                 <p class="post-meta"> 
                     {{#author}}
-                    by <a href="{{url}}" rel="nofollow" title="{{name}}">{{name}}</a>
+                    {{ translate 'post.publishedBy' }} <a href="{{url}}" rel="nofollow" title="{{name}}">{{name}}</a>
                     {{/author}} 
                     <time datetime="{{date createdAt 'YYYY-MM-DDTHH:mm'}}">
-                        {{date createdAt @config.custom.formatDate}}
+                        {{#checkIf @config.custom.formatDate '!=' 'custom'}}
+                            {{date createdAt @config.custom.formatDate}}
+                        {{else}}
+                            {{date createdAt @config.custom.formatDateCustom}}
+                        {{/checkIf}}
                     </time>
                 </p>
             </header>

--- a/app/default-files/theme-files/amp-tag.hbs
+++ b/app/default-files/theme-files/amp-tag.hbs
@@ -49,10 +49,14 @@
                 
                 <p class="card-meta">                     
                    {{#author}}
-                    by <a href="{{url}}" rel="nofollow" title="{{name}}">{{name}}</a>
+                    {{ translate 'post.publishedBy' }} <a href="{{url}}" rel="nofollow" title="{{name}}">{{name}}</a>
                     {{/author}} 
                     <time datetime="{{date createdAt 'YYYY-MM-DDTHH:mm'}}">
-                        {{date createdAt @config.custom.formatDate}}
+                        {{#checkIf @config.custom.formatDate '!=' 'custom'}}
+                            {{date createdAt @config.custom.formatDate}}
+                        {{else}}
+                            {{date createdAt @config.custom.formatDateCustom}}
+                        {{/checkIf}}
                     </time>
                 </p>
                


### PR DESCRIPTION
This fixes some missing conditions for correct rendering custom date in amp templates.
It also replaces hardcoded string `by` with translation {{ translate 'post.publishedBy' }}.