### PR TITLE
Fixes the white space problem when copying and pasting the disqus Shortname.

### DIFF
--- a/app/default-files/default-themes/simple/partials/disqus.hbs
+++ b/app/default-files/default-themes/simple/partials/disqus.hbs
@@ -19,7 +19,8 @@
 
             (function () {
                 var d = document, s = d.createElement('script');
-                s.src = 'https://{{@config.custom.commentDisqusShortname}}.disqus.com/embed.js';
+                var ui='{{@config.custom.commentDisqusShortname}}'.trim();
+                s.src = 'https://'+ui+'.disqus.com/embed.js';
                 s.setAttribute('data-timestamp', +new Date());
                 (d.head || d.body).appendChild(s);
             })();

--- a/app/default-files/default-themes/simple/partials/disqus.hbs
+++ b/app/default-files/default-themes/simple/partials/disqus.hbs
@@ -19,8 +19,7 @@
 
             (function () {
                 var d = document, s = d.createElement('script');
-                var ui='{{@config.custom.commentDisqusShortname}}'.trim();
-                s.src = 'https://'+ui+'.disqus.com/embed.js';
+                s.src = 'https://'+'{{@config.custom.commentDisqusShortname}}'.trim()+'.disqus.com/embed.js';
                 s.setAttribute('data-timestamp', +new Date());
                 (d.head || d.body).appendChild(s);
             })();


### PR DESCRIPTION
This fixes the white space problem when copying and pasting the disqus Shortname.