### PR TITLE
Added search modes and extra functions

### DIFF
--- a/app/default-files/default-themes/simple/config.json
+++ b/app/default-files/default-themes/simple/config.json
@@ -871,9 +871,9 @@
         },
         {       
             "name": "searchMode",
-            "label": "Select the search mode",
+            "label": "Mode",
             "group": "Search",           
-            "note": "Select the search mode you want.<br/>The <strong>external mode</strong> allows you to search from any external search engine in an advanced way.<br/>The <strong>internal mode</strong> will integrate the search results on your website.", 
+            "note": "The <strong>external</strong> mode allows you to search from any external search engine.<br/>The <strong>integrated</strong> mode will integrate the search results on your website.", 
             "value": "external",
             "type": "select",
             "dependencies": [{
@@ -882,12 +882,12 @@
             }],
             "options": [
                 {
-                    "label": "External mode",
+                    "label": "External",
                     "value": "external"
                 },
                 {
-                    "label": "Internal mode",
-                    "value": "internal"
+                    "label": "Integrated",
+                    "value": "integrated"
                 }                
             ]
         },
@@ -905,10 +905,10 @@
         {
             "name": "searchServer",
             "group": "Search",
-            "label": "Search engine",
+            "label": "Engine",
             "note": "Enter the URL of the search engine you want to use on your website.",
             "value": "https://duckduckgo.com",
-            "type": "text",
+            "type": "url",
             "dependencies": [{
                 "field": "search",
                 "value": "true"
@@ -921,7 +921,7 @@
         {
             "name": "searchParam",
             "group": "Search",
-            "label": "Search parameter",
+            "label": "Parameter",
             "note": "You can change the default \"q\" search parameter if desired; this is recommended only for advanced users.",
             "value": "q",
             "type": "text",
@@ -957,6 +957,17 @@
             ]
         },
         {
+            "name": "searchTab",
+            "label": "Open results in new tab",
+            "group": "Search",
+            "value": false,
+            "type": "checkbox",
+            "dependencies": [{
+                "field": "search",
+                "value": "true"
+            }]
+        },
+        {
             "name": "searchForceWebsiteResults",
             "label": "Only show results from your website",
             "group": "Search",
@@ -972,17 +983,6 @@
             }]
         },
         {
-            "name": "searchTab",
-            "label": "Open results in new tab",
-            "group": "Search",
-            "value": false,
-            "type": "checkbox",
-            "dependencies": [{
-                "field": "search",
-                "value": "true"
-            }]
-        },
-        {
             "name": "separator",
             "type": "separator",
             "label": "Google search configuration",
@@ -994,14 +994,14 @@
             },
             {
                 "field": "searchMode",
-                "value": "internal"
+                "value": "integrated"
             }]
         },
         {
             "name": "searchId",
             "group": "Search",
-            "label": "Google Custom Search Id",
-            "note": "A search ID is required for internal mode functionality, which uses Google Custom Search. Learn how to configure it here: <a href='https://getpublii.com/docs/search-configuration.html' target='_blank'>https://www.getpublii.com/docs/...</a>",
+            "label": "Custom Search Id",
+            "note": "A search ID is required for integrated mode functionality, which uses Google Custom Search. Learn how to configure it here: <a href='https://getpublii.com/docs/search-configuration.html' target='_blank'>https://www.getpublii.com/docs/...</a>",
             "value": "",
             "type": "text",
             "dependencies": [{
@@ -1010,7 +1010,7 @@
             },
             {
                 "field": "searchMode",
-                "value": "internal"
+                "value": "integrated"
             }]
         },
 

--- a/app/default-files/default-themes/simple/config.json
+++ b/app/default-files/default-themes/simple/config.json
@@ -869,16 +869,53 @@
             "value": false,
             "type": "checkbox"
         },
+        {       
+            "name": "searchMode",
+            "label": "Select the search mode",
+            "group": "Search",           
+            "note": "Select the search mode you want.<br/>The <strong>external mode</strong> allows you to search from any external search engine in an advanced way.<br/>The <strong>internal mode</strong> will integrate the search results on your website.", 
+            "value": "external",
+            "type": "select",
+            "dependencies": [{
+                "field": "search",
+                "value": "true"
+            }],
+            "options": [
+                {
+                    "label": "External mode",
+                    "value": "external"
+                },
+                {
+                    "label": "Internal mode",
+                    "value": "internal"
+                }                
+            ]
+        },
         {
-            "name": "searchId",
+            "name": "separator",
+            "type": "separator",
+            "label": "Search configuration",
             "group": "Search",
-            "label": "Google Custom Search Id",
-            "note": "A search ID is required for search functionality, which uses Google Custom Search. Learn how to configure it here: <a href='https://getpublii.com/docs/search-configuration.html' target='_blank'>https://www.getpublii.com/docs/...</a>",
-            "value": "",
+            "size": "big",
+            "dependencies": [{
+                "field": "search",
+                "value": "true"
+            }]
+        },
+        {
+            "name": "searchServer",
+            "group": "Search",
+            "label": "Search engine",
+            "note": "Enter the URL of the search engine you want to use on your website.",
+            "value": "https://duckduckgo.com",
             "type": "text",
             "dependencies": [{
                 "field": "search",
                 "value": "true"
+            },
+            {
+                "field": "searchMode",
+                "value": "external"
             }]
         },
         {
@@ -891,6 +928,89 @@
             "dependencies": [{
                 "field": "search",
                 "value": "true"
+            }]
+        },
+        {       
+            "name": "searchMethod",
+            "label": "Form Method",
+            "group": "Search",           
+            "note": "Select the method you want to use for your search engine.", 
+            "value": "get",
+            "type": "select",
+            "dependencies": [{
+                "field": "search",
+                "value": "true"
+            },
+            {
+                "field": "searchMode",
+                "value": "external"
+            }],
+            "options": [
+                {
+                    "label": "Post",
+                    "value": "post"
+                },
+                {
+                    "label": "Get",
+                    "value": "get"
+                }                
+            ]
+        },
+        {
+            "name": "searchForceWebsiteResults",
+            "label": "Only show results from your website",
+            "group": "Search",
+            "value": true,
+            "type": "checkbox",
+            "dependencies": [{
+                "field": "search",
+                "value": "true"
+            },
+            {
+                "field": "searchMode",
+                "value": "external"
+            }]
+        },
+        {
+            "name": "searchTab",
+            "label": "Open results in new tab",
+            "group": "Search",
+            "value": false,
+            "type": "checkbox",
+            "dependencies": [{
+                "field": "search",
+                "value": "true"
+            }]
+        },
+        {
+            "name": "separator",
+            "type": "separator",
+            "label": "Google search configuration",
+            "group": "Search",
+            "size": "big",
+            "dependencies": [{
+                "field": "search",
+                "value": "true"
+            },
+            {
+                "field": "searchMode",
+                "value": "internal"
+            }]
+        },
+        {
+            "name": "searchId",
+            "group": "Search",
+            "label": "Google Custom Search Id",
+            "note": "A search ID is required for internal mode, which uses Google Custom Search. Learn how to configure it here: <a href='https://getpublii.com/docs/search-configuration.html' target='_blank'>https://www.getpublii.com/docs/...</a>",
+            "value": "",
+            "type": "text",
+            "dependencies": [{
+                "field": "search",
+                "value": "true"
+            },
+            {
+                "field": "searchMode",
+                "value": "internal"
             }]
         },
 

--- a/app/default-files/default-themes/simple/config.json
+++ b/app/default-files/default-themes/simple/config.json
@@ -1001,7 +1001,7 @@
             "name": "searchId",
             "group": "Search",
             "label": "Google Custom Search Id",
-            "note": "A search ID is required for internal mode, which uses Google Custom Search. Learn how to configure it here: <a href='https://getpublii.com/docs/search-configuration.html' target='_blank'>https://www.getpublii.com/docs/...</a>",
+            "note": "A search ID is required for internal mode functionality, which uses Google Custom Search. Learn how to configure it here: <a href='https://getpublii.com/docs/search-configuration.html' target='_blank'>https://www.getpublii.com/docs/...</a>",
             "value": "",
             "type": "text",
             "dependencies": [{

--- a/app/default-files/default-themes/simple/partials/top.hbs
+++ b/app/default-files/default-themes/simple/partials/top.hbs
@@ -50,7 +50,7 @@
                             </script>
                         {{/if}}
                     {{/checkIf}}
-                    {{#checkIf @config.custom.searchMode '===' "internal"}}
+                    {{#checkIf @config.custom.searchMode '===' "integrated"}}
                         <form action="{{@website.searchUrl}}" class="search__form" {{#if @config.custom.searchTab}}target="_blank"{{/if}}>
                              <input
                                 class="search__input js-search-input"

--- a/app/default-files/default-themes/simple/partials/top.hbs
+++ b/app/default-files/default-themes/simple/partials/top.hbs
@@ -14,15 +14,53 @@
          <div class="search">
             <div class="search__overlay js-search-overlay">
                <div class="search__overlay-inner">
-                  <form action="{{@website.searchUrl}}" class="search__form">
-                     <input
-                        class="search__input js-search-input"
-                        type="search"
-                        name="{{@config.custom.searchParam}}"
-                        placeholder="{{ translate 'search.placeholder' }}" 
-                        aria-label="{{ translate 'search.placeholder' }}"
-                        autofocus="autofocus"/>
-                  </form>
+                  {{#checkIf @config.custom.searchMode '===' "external"}}
+                        <form action="{{@config.custom.searchServer}}" class="search__form" method="{{@config.custom.searchMethod}}" {{#if @config.custom.searchTab}}target="_blank"{{/if}} {{#if @config.custom.searchForceWebsiteResults}}onsubmit="changeInputSubmit();"{{/if}}>
+                            {{#if @config.custom.searchForceWebsiteResults}}
+                                <input
+                                    id="search_input"
+                                    class="search__input js-search-input"
+                                    type="search"
+                                    placeholder="{{ translate 'search.placeholder' }}" 
+                                    aria-label="{{ translate 'search.placeholder' }}"
+                                    autofocus="autofocus"
+                                />
+                                <input
+                                    id="search_go"
+                                    type="hidden"
+                                    name="{{@config.custom.searchParam}}"
+                                />
+                            {{else}}
+                                <input
+                                    class="search__input js-search-input"
+                                    type="search"
+                                    placeholder="{{ translate 'search.placeholder' }}" 
+                                    aria-label="{{ translate 'search.placeholder' }}"
+                                    autofocus="autofocus"
+                                    name="{{@config.custom.searchParam}}"
+                                />
+                            {{/if}}
+                      </form>
+                        {{#if @config.custom.searchForceWebsiteResults}}
+                            <script>
+                            function configInputSubmit(){
+                                document.getElementById('search_go').value='site:'+window.location.hostname+' '+document.getElementById('search_input').value;
+                                return true;
+                            }
+                            </script>
+                        {{/if}}
+                    {{/checkIf}}
+                    {{#checkIf @config.custom.searchMode '===' "internal"}}
+                        <form action="{{@website.searchUrl}}" class="search__form" {{#if @config.custom.searchTab}}target="_blank"{{/if}}>
+                             <input
+                                class="search__input js-search-input"
+                                type="search"
+                                name="{{@config.custom.searchParam}}"
+                                placeholder="{{ translate 'search.placeholder' }}" 
+                                aria-label="{{ translate 'search.placeholder' }}"
+                                autofocus="autofocus"/>
+                        </form>
+                    {{/checkIf}}
                   <button class="search__close js-search-close" aria-label="{{ translate 'search.close' }}">
                      {{ translate 'search.close' }}
                   </button>


### PR DESCRIPTION
I have created a new search mode.
This could be considered part of a solution for the ticket #321

When activating the search, two search modes appear:

### 1- External mode.
This mode redirects and searches any external web page.

Features of this mode:
* Possibility of inserting the URL of a search engine.
* Configurable search parameter.
* Configurable form method.
* It is allowed to "Force" external search engines to only find results from the user's website.
* It is possible to open the results in a new tab.
* This is the mode activated by default since it does not require any api key.
* By default it is configured with duckduckgo, for obvious reasons of user privacy, but it can be configured with any search engine.

Screenshot:
![imagen](https://user-images.githubusercontent.com/48658161/95003358-d89d5400-05de-11eb-8d9a-31c6a49812d6.png)

### 2- Integrated mode.
This mode integrates searches on the user's websites.

Features of this mode:
* Use the previous internal search method.
* Configurable search parameter.
* It is possible to open the results in a new tab.

Screenshot:
![imagen](https://user-images.githubusercontent.com/48658161/95003395-2b770b80-05df-11eb-9b94-af8d14d42450.png)

