### PR TITLE
Changed "select" to "radio" if you have 2 values.

### DIFF
--- a/app/default-files/default-themes/simple/config.json
+++ b/app/default-files/default-themes/simple/config.json
@@ -1377,7 +1377,7 @@
             "name": "displayDate",
             "label": "Display date",
             "value": 1,
-            "type": "radio",
+            "type": "select",
             "options": [
                 {
                     "label": "Enabled",
@@ -1393,7 +1393,7 @@
             "name": "displayAuthor",
             "label": "Display author",
             "value": 1,
-            "type": "radio",
+            "type": "select",
             "options": [
                 {
                     "label": "Enabled",
@@ -1409,7 +1409,7 @@
             "name": "displayLastUpdatedDate",
             "label": "Display last updated date",
             "value": 1,
-            "type": "radio",
+            "type": "select",
             "options": [
                 {
                     "label": "Enabled",
@@ -1425,7 +1425,7 @@
             "name": "displayTags",
             "label": "Display tags",
             "value": 1,
-            "type": "radio",
+            "type": "select",
             "options": [
                 {
                     "label": "Enabled",
@@ -1441,7 +1441,7 @@
             "name": "displayShareButtons",
             "label": "Display share buttons",
             "value": 1,
-            "type": "radio",
+            "type": "select",
             "options": [
                 {
                     "label": "Enabled",
@@ -1458,7 +1458,7 @@
             "name": "displayAuthorBio",
             "label": "Display author bio",
             "value": 1,
-            "type": "radio",
+            "type": "select",
             "options": [
                 {
                     "label": "Enabled",
@@ -1474,7 +1474,7 @@
             "name": "displayPostNavigation",
             "label": "Display post navigation",
             "value": 1,
-            "type": "radio",
+            "type": "select",
             "options": [
                 {
                     "label": "Enabled",
@@ -1491,7 +1491,7 @@
             "name": "displayRelatedPosts",
             "label": "Display related posts",
             "value": 1,
-            "type": "radio",
+            "type": "select",
             "options": [
                 {
                     "label": "Enabled",
@@ -1507,7 +1507,7 @@
             "name": "displayComments",
             "label": "Display comments",
             "value": 0,
-            "type": "radio",
+            "type": "select",
             "options": [
                 {
                     "label": "Enabled",

--- a/app/default-files/default-themes/simple/config.json
+++ b/app/default-files/default-themes/simple/config.json
@@ -524,7 +524,7 @@
             "group": "Colors",
             "note": "The overlay works with the image and only when it has been fully loaded.",
             "value": "gradient",
-            "type": "select",
+            "type": "radio",
             "options": [
                 {
                     "label": "Solid color",
@@ -1105,7 +1105,7 @@
             "group": "Gallery",
             "note": "Set the lightbox slideshow style by choosing dark or light overlay",
             "value": "pswp--dark",
-            "type": "select",
+            "type": "radio",
             "options": [
                 {
                     "label": "Dark",
@@ -1328,7 +1328,7 @@
             "group": "Additional",
             "note": "This option works only if the 'Media lazy load' option is enabled in the Website Speed tab under Site Settings",
             "value": "fadein",
-            "type": "select",
+            "type": "radio",
             "options": [
                 {
                     "label": "Fade in",
@@ -1360,7 +1360,7 @@
             "label": "Favicon extension",
             "group": "Additional",
             "value": "image/x-icon",
-            "type": "select",
+            "type": "radio",
             "options": [
                 {
                     "label": ".ico",
@@ -1377,7 +1377,7 @@
             "name": "displayDate",
             "label": "Display date",
             "value": 1,
-            "type": "select",
+            "type": "radio",
             "options": [
                 {
                     "label": "Enabled",
@@ -1393,7 +1393,7 @@
             "name": "displayAuthor",
             "label": "Display author",
             "value": 1,
-            "type": "select",
+            "type": "radio",
             "options": [
                 {
                     "label": "Enabled",
@@ -1409,7 +1409,7 @@
             "name": "displayLastUpdatedDate",
             "label": "Display last updated date",
             "value": 1,
-            "type": "select",
+            "type": "radio",
             "options": [
                 {
                     "label": "Enabled",
@@ -1425,7 +1425,7 @@
             "name": "displayTags",
             "label": "Display tags",
             "value": 1,
-            "type": "select",
+            "type": "radio",
             "options": [
                 {
                     "label": "Enabled",
@@ -1441,7 +1441,7 @@
             "name": "displayShareButtons",
             "label": "Display share buttons",
             "value": 1,
-            "type": "select",
+            "type": "radio",
             "options": [
                 {
                     "label": "Enabled",
@@ -1458,7 +1458,7 @@
             "name": "displayAuthorBio",
             "label": "Display author bio",
             "value": 1,
-            "type": "select",
+            "type": "radio",
             "options": [
                 {
                     "label": "Enabled",
@@ -1474,7 +1474,7 @@
             "name": "displayPostNavigation",
             "label": "Display post navigation",
             "value": 1,
-            "type": "select",
+            "type": "radio",
             "options": [
                 {
                     "label": "Enabled",
@@ -1491,7 +1491,7 @@
             "name": "displayRelatedPosts",
             "label": "Display related posts",
             "value": 1,
-            "type": "select",
+            "type": "radio",
             "options": [
                 {
                     "label": "Enabled",
@@ -1507,7 +1507,7 @@
             "name": "displayComments",
             "label": "Display comments",
             "value": 0,
-            "type": "select",
+            "type": "radio",
             "options": [
                 {
                     "label": "Enabled",


### PR DESCRIPTION
I have changed all the "select" that have 2 values, to "radius".
There are still "select", but only if they have more than 2 values.

### Why reason?

- 2 clicks are avoided to make simple configurations.
- With one click it can be configured.

For example, it makes no sense to perform 2 clicks on the "Post options" section, we can configure the same with one click using "radius".