### PR TITLE
AMP Whatsapp share fixed

### DIFF
--- a/app/default-files/theme-files/amp-share-buttons.hbs
+++ b/app/default-files/theme-files/amp-share-buttons.hbs
@@ -62,6 +62,7 @@
             type="whatsapp"
             width="40"
             height="40"
-            data-param-text="{{title}}">
+            data-param-text="{{title}}"
+            data-param-url="{{url}}">
     </amp-social-share>
 {{/if}}


### PR DESCRIPTION
data-param-url="{{url}}" missing in file amp-share-buttons.hbs
`{{#if @amp.shareWhatsapp}}
    <amp-social-share
            type="whatsapp"
            width="40"
            height="40"
            data-param-text="{{title}}">
    </amp-social-share>
{{/if}}`

Updated to ->
`{{#if @amp.shareWhatsapp}}
    <amp-social-share
            type="whatsapp"
            width="40"
            height="40"
            data-param-text="{{title}}"
            data-param-url="{{url}}">
    </amp-social-share>
{{/if}}`