### PR TITLE
modified emptyOutputDir in a way that we can now avoid removing files…

### DIFF
--- a/app/back-end/modules/render-html/renderer.js
+++ b/app/back-end/modules/render-html/renderer.js
@@ -405,9 +405,21 @@ class Renderer {
         if (UtilsHelper.dirExists(this.outputDir)) {
             let files = fs.readdirSync(this.outputDir);
             
+            let storeExcludes = this.siteConfig.advanced.storeExcludesArray;
+            // console.log(storeExcludes)
+
+            let storeExcludesArray = storeExcludes.split(",");
+            
+            filesIteration:
             for (let file of files) {
                 if (file === '.' || file === '..' || file === 'media') {
                     continue;
+                }
+                
+                for (let excludeName of storeExcludesArray) {
+                    if (file === excludeName.trim()) {
+                        continue filesIteration
+                    }
                 }
 
                 fs.rmdirSync(path.join(this.outputDir, file), { recursive: true });

--- a/app/src/components/Settings.vue
+++ b/app/src/components/Settings.vue
@@ -1506,6 +1506,23 @@
                             </small>
                         </field>
                     </div>
+
+                    <div slot="tab-10">
+                        <field
+                            label="Excluded Files">
+                            <input
+                                slot="field"
+                                type="text"
+                                spellcheck="false"
+                                v-model="advanced.storeExcludesArray"/>
+                            <small
+                                slot="note"
+                                class="note">
+                                Type a comma-separated list of HTML files or catalogs to exclude from the list of files that will be re-generated on Syncing the output.<br>
+                                For example: <strong>ignoreme.html,ignoreme</strong>
+                            </small>
+                        </field>
+                    </div>
                 </tabs>
             </fields-group>
 
@@ -1602,7 +1619,8 @@ export default {
                 'GDPR',
                 'Website Speed',
                 'RSS/JSON Feed',
-                'Posts Listing'
+                'Posts Listing',
+                'Sync Excludes'
             ];
         },
         seoOptions () {


### PR DESCRIPTION
modified emptyOutputDir in a way that we can now avoid removing files listed in the settings.
This is especially helpful when we share same repository and have nested websites / systems. Normally Publii would delete whole content of the output DIR except media folder.

![image](https://user-images.githubusercontent.com/74547865/99552817-b9575c00-29bd-11eb-8297-95174e3265f2.png)
