### PR TITLE
fix: Netlify deploy failed when uploading empty file

### DIFF
--- a/app/back-end/modules/deploy/libraries/netlify-api.js
+++ b/app/back-end/modules/deploy/libraries/netlify-api.js
@@ -5,7 +5,6 @@ const request = require('request');
 const crypto = require('crypto');
 const normalizePath = require('normalize-path');
 const asyncRequest = util.promisify(request);
-const asyncReadFile = util.promisify(fs.readFile);
 
 class NetlifyAPI {
     constructor (settings, events = {}) {
@@ -98,7 +97,7 @@ class NetlifyAPI {
     async uploadFile (filePath, deployID) {
         let endpointUrl = this.apiUrl + 'deploys/' + deployID + '/files' + filePath;
         let fullFilePath = this.getFilePath(this.inputDir, filePath, true);
-        let fileContent = await asyncReadFile(fullFilePath);
+        let fileContent = fs.createReadStream(fullFilePath);
         
         return asyncRequest({
             method: 'PUT',


### PR DESCRIPTION
`request` package has [code](https://github.com/request/request/blob/master/request.js#L419) that automatically applies content-length header. However, that code doesn't work if the body contains an empty file (line 434 checks if length var is truthy, and if length is 0, it's not). Because `request` package is deprecated, the bug cannot be fixed there. 

New implementation avoids the problem by using ReadStream instead of Buffer.

See [#956](https://github.com/GetPublii/Publii/issues/956) for more info how this bug is visible to the end user.

### Steps to reproduce

Try to deploy to Netlify when project theme contains an empty main.css file.