### PR TITLE
feat: add thumbnail ('media:content') to entries in feed.xml

### DIFF
--- a/app/default-files/theme-files/feed-xml.hbs
+++ b/app/default-files/theme-files/feed-xml.hbs
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<feed xmlns="http://www.w3.org/2005/Atom">
+<feed xmlns="http://www.w3.org/2005/Atom" xmlns:media="http://search.yahoo.com/mrss/">
     <title>{{siteName}}</title>
     <link href="{{siteDomain}}/feed.xml" rel="self" />
     <link href="{{siteDomain}}" />
@@ -21,6 +21,9 @@
         </author>
         <link href="{{url}}"/>
         <id>{{url}}</id>
+        {{#if thumbnail}}
+        <media:content url="{{thumbnail.url}}" medium="image" />
+        {{/if}}
         {{#each categories}}
             <category term="{{name}}"/>
         {{/each}}


### PR DESCRIPTION
I am evaluating Blogging platforms and have settled on Publii (over Wordpress!). One item I was struggling with is that the `feed.xml` for Publii did not contain `<media:content>` images for either thumbnails or featured images. I could see that the `feed.json` did include an image per entry. I would use the json feed directly for my purposes, but 3rd party integrations do not have very robust support for non-RSS/Atom feeds.

This change allows me to use Zapier's RSS integration to post Image posts to FB Groups, Instagram and Twitter. Without this I can only post non-image posts which look very very bland indeed. I had this working in Wordpress before with a Plugin, and almost worked around this using a few lines of Python and a GitHub Action to search the HTML per post and add the first img link as a `media:content` tag, but thought I would try push a fix upstream rather than working around my issue.

I have verified that the feed.xml generated by this PR is valid in Firefox's native XML preview and the online checker at https://validator.w3.org