### PR TITLE
fix: wxr page import

### DIFF
--- a/app/back-end/modules/import/wxr-parser.js
+++ b/app/back-end/modules/import/wxr-parser.js
@@ -549,7 +549,7 @@ class WxrParser {
             }, false);
 
             let newPageResult = newPage.save();
-            let newPageID = newPageResult.postID;
+            let newPageID = newPageResult.pageID;
 
             this.temp.pages[pageSlug] = newPageID;
             this.temp.mapping.pages[pages[i]['wp:post_id']] = newPageID;
@@ -581,7 +581,7 @@ class WxrParser {
                 });
 
                 let featuredPageID = newPage.db.prepare('SELECT last_insert_rowid() AS id').get().id;
-                let featuredPageIdUpdate = newPage.db.prepare(`UPDATE posts SET featured_image_id = @featuredPostID WHERE id = @newPageID`);
+                let featuredPageIdUpdate = newPage.db.prepare(`UPDATE posts SET featured_image_id = @featuredPageID WHERE id = @newPageID`);
 
                 featuredPageIdUpdate.run({
                     featuredPageID,

--- a/app/default-files/default-languages/en-gb/translations.json
+++ b/app/default-files/default-languages/en-gb/translations.json
@@ -86,6 +86,7 @@
             "imageDownloadError": "An error occurred during downloading of the image: {image}",
             "imagesProgressInfo": "Downloading images ({progress} / {total})",
             "postsProgressInfo": "Importing posts ({progress} / {total})",
+            "pagesProgressInfo": "Importing pages ({progress} / {total})",
             "tagsProgressInfo": "Importing tags ({progress} / {total})"
         }
     },


### PR DESCRIPTION
Hello,

I encountered some errors when trying importing an existing WP blog into Publii:
- the progress message showed a translation key when reaching the part for importing pages, so I added some words for this key
- the page import was hanging. After some debugging, I spotted typos in wxr-parser.js: postId was used instead of pageId
