### PR TITLE
fix: thumbnail regen hanging

### DIFF
--- a/app/back-end/workers/thumbnails/regenerate.js
+++ b/app/back-end/workers/thumbnails/regenerate.js
@@ -66,6 +66,7 @@ function regenerateImages(mediaPath, catalog) {
  */
 function regenerateImage (images, fullPath, catalog) {
     if (!images.length) {
+        context.totalProgress++;
         return;
     }
 


### PR DESCRIPTION
Hello,

When triggering the thumbnail regeneration process on a few hundred images, it kept hanging.

I did some debugging and found out that regenerateImages() was stuck in a loop.
It happened when the method was called at least once with an empty array as the first argument.
To fix it, I added an increment on totalProgress before the first early return.
