### PR TITLE
fix: preview fails when page has missing author

### DIFF
--- a/app/back-end/modules/render-html/contexts/page.js
+++ b/app/back-end/modules/render-html/contexts/page.js
@@ -103,11 +103,11 @@ class RendererContextPage extends RendererContext {
         if (this.metaTitle === '') {
             this.metaTitle = this.siteConfig.advanced.pageMetaTitle.replace(/%pagetitle/g, this.page.title)
                                                                    .replace(/%sitename/g, siteName)
-                                                                   .replace(/%authorname/g, this.page.author.name);
+                                                                   .replace(/%authorname/g, this.page.author?.name);
         } else {
             this.metaTitle = this.metaTitle.replace(/%pagetitle/g, this.page.title)
                                            .replace(/%sitename/g, siteName)
-                                           .replace(/%authorname/g, this.page.author.name);
+                                           .replace(/%authorname/g, this.page.author?.name);
         }
 
         // If still meta title is empty - use page title
@@ -117,7 +117,7 @@ class RendererContextPage extends RendererContext {
 
         this.metaDescription = this.metaDescription.replace(/%pagetitle/g, this.page.title)
                                                     .replace(/%sitename/g, siteName)
-                                                    .replace(/%authorname/g, this.page.author.name);
+                                                    .replace(/%authorname/g, this.page.author?.name);
 
         this.context = {
             title: this.metaTitle,


### PR DESCRIPTION
After importing a WP blog into Publii, the preview changes process failed with the following error:
<details><summary>Details</summary>
<p>
    TypeError: Cannot read properties of undefined (reading 'name')
        at RendererContextPage.setContext (/home/git/fork-Publii/app/back-end/modules/render-html/contexts/page.js:110:86)
        at RendererContextPage.getContext (/home/git/fork-Publii/app/back-end/modules/render-html/contexts/page.js:144:14)
        at Renderer.generatePages (/home/git/fork-Publii/app/back-end/modules/render-html/renderer.js:1279:44)
        at Renderer.generateWWW (/home/git/fork-Publii/app/back-end/modules/render-html/renderer.js:242:18)
        at Renderer.renderFullPreview (/home/git/fork-Publii/app/back-end/modules/render-html/renderer.js:193:20)
        at Renderer.renderSite (/home/git/fork-Publii/app/back-end/modules/render-html/renderer.js:174:28)
        at Renderer.render (/home/git/fork-Publii/app/back-end/modules/render-html/renderer.js:119:24)
        at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
        at async process.<anonymous> (/home/git/fork-Publii/app/back-end/workers/renderer/preview.js:17:22)
</p>
</details> 

To fix it, I added optional chaining operators in `app/back-end/modules/render-html/contexts/page.js` when accessing a page's author's name