### PR TITLE
Update main.css to fix issue with too much space under photos 

### DIFF
--- a/app/default-files/default-themes/simple/assets/css/main.css
+++ b/app/default-files/default-themes/simple/assets/css/main.css
@@ -122,7 +122,6 @@ hr,
 pre,
 table {
   margin-top: calc(var(--baseline) * 6 + 0.5vw);
-  margin-bottom: calc(var(--baseline) * 6 + 0.5vw);
 }
 
 h1,


### PR DESCRIPTION
In order to more accurately match the post previews, remove this css to prevent overly-large margins under photos. 
<img width="670" alt="SCR-20250110-tntt" src="https://github.com/user-attachments/assets/645daecc-9990-49c9-98ca-4bdee043e061" />
![SCR-20250110-toal](https://github.com/user-attachments/assets/03ef19fd-2ea1-4e69-9de0-34c44409b4ad)
<img width="616" alt="SCR-20250110-toje" src="https://github.com/user-attachments/assets/9637d1b6-8695-48f7-8736-11e5a9985b5d" />
