### PR TITLE
feat: UI improvement - clearly defined Quick Preview button

### DIFF
--- a/app/default-files/default-languages/en-gb/translations.json
+++ b/app/default-files/default-languages/en-gb/translations.json
@@ -1435,6 +1435,7 @@
         "pleaseFillAllRequiredFields": "Please fill all required fields",
         "posts": "Posts",
         "preview": "Preview",
+        "previewQuick": "Quick Preview",
         "previewFrontPageOnly": "Preview homepage only",
         "previewFullWebsite": "Preview full website",
         "publiiOnGithub": "View Publii on Github",

--- a/app/default-files/default-languages/pl/translations.json
+++ b/app/default-files/default-languages/pl/translations.json
@@ -1434,6 +1434,7 @@
         "pleaseFillAllRequiredFields": "Proszę wypełnić wszystkie wymagane pola",
         "posts": "Wpisy",
         "preview": "Podgląd",
+        "previewQuick": "Szybki Podgląd",
         "previewFrontPageOnly": "Podejrzyj tylko stronę główną",
         "previewFullWebsite": "Podejrzyj całą stronę",
         "publiiOnGithub": "Zobacz Publii na Github",

--- a/app/src/components/post-editor/TopBar.vue
+++ b/app/src/components/post-editor/TopBar.vue
@@ -18,19 +18,19 @@
             </template>
         </p-button>
 
-        <p-button
-            v-if="!sourceCodeEditorVisible"
-            id="post-preview-button"
-            type="clean-invert"
-            :disabled="!themeConfigured"
-            :title="themeConfigured ? $t('post.configureThemeBeforeGeneratingPreview') : ''"
-            @click.native="generatePostPreview">
-            {{ $t('ui.preview') }}
-        </p-button>
-
         <div
             v-if="!sourceCodeEditorVisible"
             class="post-editor-actions">
+
+            <p-button
+                v-if="!sourceCodeEditorVisible"
+                id="post-preview-button"
+                type="secondary icon"
+                icon="quick-preview"
+                :title="themeConfigured ? $t('post.configureThemeBeforeGeneratingPreview') : ''"
+                @click.native="generatePostPreview">
+                {{ $t('ui.previewQuick') }}
+            </p-button>
 
             <btn-dropdown
                 ref="dropdown-button"
@@ -260,6 +260,10 @@ export default {
 
             &:nth-child(2) {
                 margin-left: 1rem;
+            }
+
+            &:nth-child(3) {
+                margin-left: 1rem;
                 margin-right: -1.7rem; // button padding
             }
         }
@@ -269,10 +273,6 @@ export default {
         margin-left: auto;
     }
 
-    #post-preview-button {
-        background: var(--bg-primary);
-    }
-
     #post-back-to-posts-button {
         background: var(--bg-primary);
         margin-left: -2.1rem;
@@ -280,14 +280,6 @@ export default {
         padding-left: 3.4rem;
         padding-right: .625rem;
         position: relative;
-
-        &::after {
-            border-right: 1px solid var(--gray-2);
-            content: "";
-            height: 1.4rem;
-            right: -.9375rem;
-            @include centerXY(false, true);
-        }
     }
 }
 


### PR DESCRIPTION
Clearly defined Quick Preview button to align with its function.

- Moved the preview button which gets lost in the design to be next to the save button.
- Updated the button and surrounding UI to align with global styles
- Changed "Preview" to "Quick Preview" to align with what the button actually does, only rendering a single page/post.
- Added translations for ui.previewQuick