### PR TITLE
fix: NoSuchKey: Key not found on S3 deploy

### DIFF
--- a/app/back-end/modules/deploy/s3.js
+++ b/app/back-end/modules/deploy/s3.js
@@ -313,7 +313,17 @@ class S3 {
             await this.removeFile();
         } catch (err) {
             console.error(`[${new Date().toUTCString()}] Error deleting ${input}`, err);
-            this.onError(err, true);
+
+            if (err.name !== 'NoSuchKey') {
+                this.onError(err, true);
+                return;
+            }
+
+            this.deployment.currentOperationNumber++;
+            console.log(`[${ new Date().toUTCString() }] DEL ${input}`);
+            this.deployment.progressOfDeleting += this.deployment.progressPerFile;
+            this.sendProgress(8 + Math.floor(this.deployment.progressOfDeleting));
+            await this.removeFile();
         }
     }
 


### PR DESCRIPTION
When I was deploying a website on Garage's S3 hosting at [RésiLien](https://resilien.fr), I encountered an issue with [this line](https://github.com/GetPublii/Publii/blob/0d376e7513eb6e7f55ae51ebb7109153aaa0a90f/app/back-end/modules/deploy/s3.js#L307).

Unfortunately, I didn't save the exact error, but I noted the line and noticed that you had added a safeguard for this type of error earlier [in the code](https://github.com/GetPublii/Publii/blob/0d376e7513eb6e7f55ae51ebb7109153aaa0a90f/app/back-end/modules/deploy/s3.js#L146-L149).

I resolved the issue by manually deleting all the files from the Filestash application, which returned the same error but ended up deleting everything.

I successfully synchronized my website again afterward.

Maybe this fix it.