### PR TITLE
fix: correct typo by replacing updatedHierarchy with pagesHierarchy

### DIFF
--- a/app/back-end/events/page.js
+++ b/app/back-end/events/page.js
@@ -115,7 +115,7 @@ class PageEvents {
             
             pagesHierarchy = this.removeNullDataFromHierarchy(pagesHierarchy);
             pagesHierarchy = this.removeDuplicatedDataFromHierarchy(pagesHierarchy);
-            fs.writeFileSync(pagesFile, JSON.stringify(updatedHierarchy, null, 4), { encoding: 'utf8' });
+            fs.writeFileSync(pagesFile, JSON.stringify(pagesHierarchy, null, 4), { encoding: 'utf8' });
         });
     }
 


### PR DESCRIPTION
fix: correct typo by replacing updatedHierarchy with pagesHierarchy

branch: fix-typo-updatedHierarchy