### PR TITLE
fix: Add config showHeader to Post list config for simple theme

### DIFF
--- a/app/default-files/default-themes/simple/config.json
+++ b/app/default-files/default-themes/simple/config.json
@@ -235,6 +235,13 @@
             "size": "small thin "
         },
         {
+            "name": "showHeader",
+            "group": "Post list",
+            "label": "Show Header text",
+            "value": true,
+            "type": "checkbox"
+        },
+        {
             "name": "feedFeaturedImage",
             "group": "Post list",
             "label": "Show Featured Image",

--- a/app/default-files/default-themes/simple/posts.hbs
+++ b/app/default-files/default-themes/simple/posts.hbs
@@ -1,18 +1,20 @@
 {{> head}}
 {{> navbar}}
 <main class="posts">
-   <div class="hero hero--noimage">
-      <header class="hero__content {{#checkIf @config.custom.alignHero '==' "center" }}hero__content--centered{{/checkIf}}">
-         <div class="wrapper">
-            <h1>
-               {{ translate 'postPrefix.title' }} 
-            </h1>
-            <p class="page__desc">
-               {{ translate "postPrefix.description" }}
-            </p>
-         </div>
-      </header>
-   </div>
+  {{#if @config.custom.showHeader}}
+     <div class="hero hero--noimage">
+        <header class="hero__content {{#checkIf @config.custom.alignHero '==' "center" }}hero__content--centered{{/checkIf}}">
+           <div class="wrapper">
+              <h1>
+                 {{ translate 'postPrefix.title' }} 
+              </h1>
+              <p class="page__desc">
+                 {{ translate "postPrefix.description" }}
+              </p>
+           </div>
+        </header>
+     </div>
+  {{/if}}
    <div class="wrapper feed">
       {{#each posts}}
          <article class="feed__item {{#checkIf @config.custom.alignFeed '==' "center" }}feed__item--centered{{/checkIf}}">


### PR DESCRIPTION
I ran into the same issue as the poster here: https://github.com/GetPublii/Publii/discussions/1961

I made a small change to the simple theme config that allows you to show or hide the header text. It would be nice to make the text itself configurable down the road, but I figured showing and hiding the text was at least desirable.