### PR TITLE
fix: add repeater type to post settings and fix style

### DIFF
--- a/app/src/components/basic-elements/Repeater.vue
+++ b/app/src/components/basic-elements/Repeater.vue
@@ -25,7 +25,10 @@
             <div 
                 v-for="(row, index) of content"
                 :key="'publii-repeater-row-' + index"
-                class="publii-repeater-item">
+                :class="{
+                    'publii-repeater-item': true,
+                    'publii-repeater-item-with-labels': (!hideLabels || (hideLabels && index === 0))
+                }">
                 <span 
                     v-if="content.length > 1"
                     class="move">
@@ -485,7 +488,8 @@ export default {
         display: flex;
         flex-wrap: wrap;
         position: relative;
-        width: calc(100% - 68px);
+        width: calc(100% - 20px - 68px);
+        margin-left: 20px;
 
         &-ui {
             display: flex;
@@ -547,14 +551,15 @@ export default {
         }
 
         &-field {
+            width: 100%;
+
             label {
+                color: var(--label-color);
                 padding-right: 10px;
 
                 & > span {
                     display: block;
-                    font-size: 1.4rem;
-                    font-weight: bold;
-                    margin: 0 0 1rem 0;
+                    line-height: 2.6;
                 }
 
                 & > * {
@@ -650,12 +655,12 @@ export default {
             }
         }
 
-        &:first-child {
+        &-with-labels {
             .move {
-                top: 3.24rem
+                top: 2.6em
             }
             .publii-repeater-item-ui {
-                top: 3.24rem
+                top: 2.6em
             }
         }
     }

--- a/app/src/components/post-editor/Sidebar.vue
+++ b/app/src/components/post-editor/Sidebar.vue
@@ -541,6 +541,20 @@
                                         :item-id="$parent.postID"
                                         imageType="contentImages" />
 
+                                    <repeater
+                                        v-if="field.type === 'repeater'" 
+                                        slot="field"
+                                        :structure="field.structure"
+                                        v-model="$parent.postData.viewOptions[field.name]"
+                                        :translations="field.translations"
+                                        :maxCount="field.maxCount"
+                                        :hasEmptyState="field.hasEmptyState"
+                                        :hideLabels="field.hideLabels"
+                                        :anchor="field.anchor"
+                                        :settings="$parent.postData.viewOptions"
+                                        imageType="contentImages"
+                                        :customCssClasses="field.customCssClasses" />
+
                                     <small
                                         v-if="field.note"
                                         class="note">


### PR DESCRIPTION
Hi, I wanted to use a repeater-type setting on a page and this wasn't possible yet.

- Added repeater type to the post editor sidebar.
- Indented the repeater items by 20px to distinguish them from top-level settings and to make space for the 'move' handle (otherwise clipped off on the post editor sidebar due to its `overflow:hidden`).
- Fixed the repeater item style to make the labels consistent with those of the other settings, both in theme settings and post/page settings.
- Fixed the offset of the 'move' and 'ui' elements for `hideLabels: false`.

I've tested both the post settings and theme settings as much as I could, but this is my first PR to this project. Happy to make any changes.