### PR TITLE
Fix stored XSS in JSON-LD and meta-robots helpers (CWE-79)

### DIFF
--- a/app/back-end/modules/render-html/handlebars/helpers/json-ld.js
+++ b/app/back-end/modules/render-html/handlebars/helpers/json-ld.js
@@ -203,7 +203,7 @@ function jsonLDHelper(rendererInstance, Handlebars) {
         }
 
         output += '<script type="application/ld+json">';
-        output += JSON.stringify(jsonLDObject);
+        output += JSON.stringify(jsonLDObject).replace(/</g, '\\u003c').replace(/>/g, '\\u003e').replace(/&/g, '\\u0026');
         output += '</script>';
         moment.locale(momentOriginalLocale);
         return new Handlebars.SafeString(output);

--- a/app/back-end/modules/render-html/handlebars/helpers/meta-robots.js
+++ b/app/back-end/modules/render-html/handlebars/helpers/meta-robots.js
@@ -37,7 +37,13 @@ function metaRobotsHelper(rendererInstance, Handlebars) {
         }
 
         if (options.data.root.metaRobotsRaw !== '') {
-            return new Handlebars.SafeString('<meta name="robots" content="' + options.data.root.metaRobotsRaw + '">');
+            let safeRobots = String(options.data.root.metaRobotsRaw)
+                .replace(/&/g, '&amp;')
+                .replace(/"/g, '&quot;')
+                .replace(/'/g, '&#x27;')
+                .replace(/</g, '&lt;')
+                .replace(/>/g, '&gt;');
+            return new Handlebars.SafeString('<meta name="robots" content="' + safeRobots + '">');
         }
 
         return '';


### PR DESCRIPTION
## Security Fix — Stored XSS (CWE-79)

Fixes two stored XSS vulnerabilities in the HTML rendering helpers that affect
the **generated static website** served to visitors.

Related: #2602

---

### VULN-001 — `json-ld.js` (High, CVSS 7.3)

**Root cause**: `JSON.stringify()` does not escape `<` or `>`, so any string value
(post title, author name, description) containing `</script>` prematurally terminates
the `<script type="application/ld+json">` block. Everything after the injected
`</script>` is parsed as HTML and executed.

**Attack vector**: Import a malicious WXR file with a post title containing
`</script><script>alert(document.domain)</script>` → publish site → XSS for all visitors.

**Proof** (Node.js):
```js
JSON.stringify({headline: 'Post</script><script>alert(1)</script>'})
// → '{"headline":"Post</script><script>alert(1)</script>"}' ← unescaped
```

**Fix**: Unicode-escape `<`, `>`, `&` — valid JSON, safe for HTML embedding.

```js
// Before
output += JSON.stringify(jsonLDObject);

// After
output += JSON.stringify(jsonLDObject)
    .replace(/</g, '\\u003c')
    .replace(/>/g, '\\u003e')
    .replace(/&/g, '\\u0026');
```

---

### VULN-002 — `meta-robots.js` (Medium, CVSS 5.4)

**Root cause**: `metaRobotsRaw` is interpolated into `content=""` without HTML encoding.
A `"` in the value terminates the attribute, allowing HTML injection.

**Fix**: HTML-encode the value before interpolation.

```js
// Before
'<meta name="robots" content="' + options.data.root.metaRobotsRaw + '">'

// After — HTML-encode first
let safeRobots = String(options.data.root.metaRobotsRaw)
    .replace(/&/g, '&amp;').replace(/"/g, '&quot;')
    .replace(/'/g, '&#x27;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
'<meta name="robots" content="' + safeRobots + '">'
```

---

### Verification

```js
// After fix — </script> is safe
JSON.stringify({headline: 'Test</script>'})
    .replace(/</g, '\\u003c').replace(/>/g, '\\u003e')
// → '{"headline":"Test\\u003c/script\\u003e"}' ← browser cannot break out
```

The unicode-escaped JSON remains fully valid — parsers and search engines read
the original characters correctly.