### PR TITLE
fix: clean site configs when uninstalling plugins

### DIFF
--- a/app/back-end/plugins.js
+++ b/app/back-end/plugins.js
@@ -211,6 +211,30 @@ class Plugins {
         }
 
         UtilsHelper.removePathRecursively(target);
+        this.removePluginFromSiteConfigs(directory);
+    }
+
+    /**
+     * Remove an uninstalled plugin from every site's activation config
+     */
+    removePluginFromSiteConfigs (directory) {
+        if (!PathValidator.isValidDirSegment(directory) || !UtilsHelper.dirExists(this.sitesDir)) {
+            return;
+        }
+
+        let sites = fs.readdirSync(this.sitesDir);
+
+        for (let i = 0; i < sites.length; i++) {
+            let siteName = sites[i];
+
+            if (!PathValidator.isValidDirSegment(siteName) ||
+                !UtilsHelper.dirExists(path.join(this.sitesDir, siteName))) {
+                continue;
+            }
+
+            // Loading validates the saved list against the plugins that still exist.
+            this.loadSitePluginsConfig(siteName);
+        }
     }
 
     getPluginConfig (siteName, pluginName) {

--- a/app/back-end/plugins.spec.js
+++ b/app/back-end/plugins.spec.js
@@ -1,0 +1,78 @@
+const assert = require('assert');
+const fs = require('fs-extra');
+const os = require('os');
+const path = require('path');
+const Plugins = require('./plugins.js');
+
+describe('Plugins', function () {
+    let tempDir;
+    let appDir;
+    let sitesDir;
+    let originalConsoleLog;
+
+    beforeEach(function () {
+        originalConsoleLog = console.log;
+        console.log = function () {};
+        tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'publii-plugins-'));
+        appDir = path.join(tempDir, 'app');
+        sitesDir = path.join(tempDir, 'sites');
+        fs.ensureDirSync(path.join(appDir, 'plugins', 'removed-plugin'));
+        fs.ensureDirSync(path.join(appDir, 'plugins', 'retained-plugin'));
+        fs.ensureDirSync(sitesDir);
+    });
+
+    afterEach(function () {
+        console.log = originalConsoleLog;
+        fs.removeSync(tempDir);
+    });
+
+    function writeSiteConfig (siteName, config) {
+        let configPath = path.join(sitesDir, siteName, 'input', 'config', 'site.plugins.json');
+        fs.ensureDirSync(path.dirname(configPath));
+        fs.writeFileSync(configPath, JSON.stringify(config, null, 4));
+        return configPath;
+    }
+
+    it('removes an uninstalled plugin from every site config immediately', function () {
+        let activeConfigPath = writeSiteConfig('active-site', {
+            'removed-plugin': true,
+            'retained-plugin': true
+        });
+        let inactiveConfigPath = writeSiteConfig('inactive-site', {
+            'removed-plugin': false,
+            'retained-plugin': false
+        });
+        let unrelatedConfigPath = writeSiteConfig('unrelated-site', {
+            'retained-plugin': true
+        });
+        let plugins = new Plugins(appDir, sitesDir);
+
+        plugins.removePlugin('removed-plugin');
+
+        assert.strictEqual(fs.existsSync(path.join(appDir, 'plugins', 'removed-plugin')), false);
+        assert.deepStrictEqual(fs.readJsonSync(activeConfigPath), {
+            'retained-plugin': true
+        });
+        assert.deepStrictEqual(fs.readJsonSync(inactiveConfigPath), {
+            'retained-plugin': false
+        });
+        assert.deepStrictEqual(fs.readJsonSync(unrelatedConfigPath), {
+            'retained-plugin': true
+        });
+    });
+
+    it('leaves an invalid site config untouched while cleaning valid sites', function () {
+        let invalidConfigPath = path.join(sitesDir, 'invalid-site', 'input', 'config', 'site.plugins.json');
+        fs.ensureDirSync(path.dirname(invalidConfigPath));
+        fs.writeFileSync(invalidConfigPath, '{invalid json');
+        let validConfigPath = writeSiteConfig('valid-site', {
+            'removed-plugin': true
+        });
+        let plugins = new Plugins(appDir, sitesDir);
+
+        plugins.removePlugin('removed-plugin');
+
+        assert.strictEqual(fs.readFileSync(invalidConfigPath, 'utf8'), '{invalid json');
+        assert.strictEqual(fs.readJsonSync(validConfigPath)['removed-plugin'], undefined);
+    });
+});


### PR DESCRIPTION
## What changed

- refresh every site's plugin activation config immediately after a plugin directory is removed
- reuse the existing config validator, so stale entries are removed through the same path already used by the Plugins screen
- skip non-site entries and preserve malformed site config files instead of overwriting them
- add regression coverage for active, inactive, unrelated, and malformed site configs

This fixes the reproduction in [discussion #2671](https://github.com/GetPublii/Publii/discussions/2671): Preview no longer sees an active reference to a plugin that has already been uninstalled.

## Verification

- `app/back-end/plugins.spec.js`: 2 passing
- JavaScript syntax checks pass for the implementation and regression test
- `npm run prod`: compiles successfully with Node 24.19.0
- full test suite on this branch: 100 passing, 3 failing
- untouched `master`: 98 passing, the same 3 pre-existing `feedLink` whitespace failures
- `git diff --check`: passes

## Scope

No plugin API, activation UI, renderer behavior, or unrelated site data is changed. The patch only triggers existing site-plugin-list validation after a successful uninstall.

Authored and tested by an autonomous AI agent operating the `fablgen-agent` account.
