### PR TITLE
Add native LaTeX SVG rendering for Markdown

### DIFF
--- a/app/back-end/modules/render-html/helpers/template.js
+++ b/app/back-end/modules/render-html/helpers/template.js
@@ -19,6 +19,7 @@ class TemplateHelper {
         this.themeConfig = this.loadThemeConfig();
         this.loadedTemplates = {};
         this.loadedPartialTemplates = {};
+        this.pendingWrites = [];
     }
 
     /*
@@ -94,7 +95,7 @@ class TemplateHelper {
         }
 
         fs.ensureDirSync(path.parse(filePath).dir);
-        fs.writeFile(filePath, content, {'flags': 'w'});
+        this.writeFile(filePath, content);
     }
 
     saveOutputPostFile (postSlug, content) {
@@ -117,7 +118,7 @@ class TemplateHelper {
             fs.ensureDirSync(dirPath);
         }
 
-        fs.writeFile(filePath, content, {'flags': 'w'});
+        this.writeFile(filePath, content);
     }
 
     saveOutputHomePaginationFile(pageNumber, content) {
@@ -137,7 +138,7 @@ class TemplateHelper {
         // Create dir for specific page
         fs.ensureDirSync(dirPath);
         // Create index.html file in the created dir
-        fs.writeFile(filePath, content, {'flags': 'w'});
+        this.writeFile(filePath, content);
     }
 
     saveOutputPageFile (pageID, pageSlug, content, renderer) {
@@ -152,7 +153,7 @@ class TemplateHelper {
         if (this.siteConfig.advanced.usePageAsFrontpage && this.siteConfig.advanced.pageAsFrontpage === pageID) {
             let filePath = path.join(this.outputDir, 'index.html');
             content = this.compressHTML(content);
-            fs.writeFile(filePath, content, {'flags': 'w'});
+            this.writeFile(filePath, content);
             return;
         }
 
@@ -177,7 +178,7 @@ class TemplateHelper {
             fs.ensureDirSync(dirPath);
         }
 
-        fs.writeFile(filePath, content, {'flags': 'w'});
+        this.writeFile(filePath, content);
     }
 
     /*
@@ -192,7 +193,7 @@ class TemplateHelper {
         let dirPath = path.join(baseDir, tagsPrefix);
         fs.ensureDirSync(dirPath);
         content = this.compressHTML(content);
-        fs.writeFile(filePath, content, {'flags': 'w'});
+        this.writeFile(filePath, content);
     }
     
     /*
@@ -211,7 +212,7 @@ class TemplateHelper {
         if (isTagPreview) {
             filePath = path.join(this.outputDir, 'preview.html');
             content = this.compressHTML(content);
-            fs.writeFile(filePath, content, {'flags': 'w'});
+            this.writeFile(filePath, content);
             return;
         } else if (tagsPrefix) {
             filePath = path.join(baseDir, tagsPrefix, tagSlug, 'index.html');
@@ -225,7 +226,7 @@ class TemplateHelper {
 
         content = this.compressHTML(content);
         fs.ensureDirSync(dirPath);
-        fs.writeFile(filePath, content, {'flags': 'w'});
+        this.writeFile(filePath, content);
     }
 
     saveOutputTagPaginationFile(tagSlug, pageNumber, content) {
@@ -263,7 +264,7 @@ class TemplateHelper {
         }
 
         // Create index.html file in the created dir
-        fs.writeFile(filePath, content, {'flags': 'w'});
+        this.writeFile(filePath, content);
     }
 
     /*
@@ -280,13 +281,13 @@ class TemplateHelper {
         if (isAuthorPreview) {
             filePath = path.join(this.outputDir, 'preview.html');
             content = this.compressHTML(content);
-            fs.writeFile(filePath, content, {'flags': 'w'});
+            this.writeFile(filePath, content);
             return;
         }
 
         content = this.compressHTML(content);
         fs.ensureDirSync(dirPath);
-        fs.writeFile(filePath, content, {'flags': 'w'});
+        this.writeFile(filePath, content);
     }
 
     saveOutputAuthorPaginationFile(authorSlug, pageNumber, content) {
@@ -303,7 +304,26 @@ class TemplateHelper {
         // Create dir for specific page
         fs.ensureDirSync(dirPath);
         // Create index.html file in the created dir
-        fs.writeFile(filePath, content, {'flags': 'w'});
+        this.writeFile(filePath, content);
+    }
+
+    writeFile (filePath, content) {
+        this.pendingWrites.push(
+            fs.writeFile(filePath, content, {'flags': 'w'})
+                .then(() => false)
+                .catch(error => error)
+        );
+    }
+
+    async waitForPendingWrites () {
+        let pendingWrites = this.pendingWrites;
+        this.pendingWrites = [];
+        let results = await Promise.all(pendingWrites);
+        let writeError = results.find(result => result instanceof Error);
+
+        if (writeError) {
+            throw writeError;
+        }
     }
 
     /*

--- a/app/back-end/modules/render-html/renderer.js
+++ b/app/back-end/modules/render-html/renderer.js
@@ -36,6 +36,7 @@ const UtilsHelper = require('./../../helpers/utils');
 const Sitemap = require('./helpers/sitemap.js');
 const Gdpr = require('./helpers/gdpr.js');
 const Git = require('./../deploy/git.js');
+const LatexToSvg = require('./text-renderers/latex.js');
 
 // Default config
 const defaultAstCurrentSiteConfig = require('./../../../config/AST.currentSite.config');
@@ -175,6 +176,24 @@ class Renderer {
             } else {
                 await this.renderFullPreview();
             }
+
+            await this.templateHelper.waitForPendingWrites();
+            let latexWarnings = await LatexToSvg.processDirectory(this.outputDir);
+
+            for (let warning of latexWarnings) {
+                console.warn(
+                    `[LaTeX] ${warning.source}: ${warning.message} (${warning.formula})`
+                );
+            }
+
+            if (
+                !this.singlePageMode &&
+                !this.homepageOnlyMode &&
+                !this.tagOnlyMode &&
+                !this.authorOnlyMode
+            ) {
+                this.sendProgress(100, 'Website files are ready to upload');
+            }
         } catch (e) {
             this.errorLog.push({
                 message: 'An error occurred during rendering process:',
@@ -193,6 +212,7 @@ class Renderer {
         this.preparePageToRender();
         this.triggerEvent('beforeRender');
         await this.generateWWW();
+        await this.templateHelper.waitForPendingWrites();
         console.timeEnd("RENDERING");
 
         if (this.siteConfig.deployment.relativeUrls) {
@@ -201,7 +221,6 @@ class Renderer {
             console.timeEnd("RELATIVE URLS");
         }
 
-        this.sendProgress(100, 'Website files are ready to upload');
         this.db.close();
     }
 

--- a/app/back-end/modules/render-html/text-renderers/latex.js
+++ b/app/back-end/modules/render-html/text-renderers/latex.js
@@ -1,0 +1,172 @@
+const fs = require('fs-extra');
+const path = require('path');
+const { pathToFileURL } = require('url');
+
+const PLACEHOLDER_PATTERN = /<publii-math data-publii-latex="([A-Za-z0-9_-]+)">[\s\S]*?<\/publii-math>/g;
+
+class LatexToSvg {
+    static createPlaceholder (tex, display, source) {
+        let payload = Buffer.from(JSON.stringify({
+            tex,
+            display,
+            source
+        }), 'utf8').toString('base64url');
+
+        return `<publii-math data-publii-latex="${payload}">${LatexToSvg.escapeHtml(source)}</publii-math>`;
+    }
+
+    static async processDirectory (outputDir) {
+        LatexToSvg.formulaCache.clear();
+        let htmlFiles = await LatexToSvg.findHtmlFiles(outputDir);
+        let warnings = [];
+
+        for (let htmlFile of htmlFiles) {
+            let content = await fs.readFile(htmlFile, 'utf8');
+
+            if (content.indexOf('<publii-math data-publii-latex=') === -1) {
+                continue;
+            }
+
+            let result = await LatexToSvg.processContent(content, htmlFile);
+            warnings.push(...result.warnings);
+
+            if (result.content !== content) {
+                await fs.writeFile(htmlFile, result.content, 'utf8');
+            }
+        }
+
+        return warnings;
+    }
+
+    static async processContent (content, sourceName = '') {
+        let matches = Array.from(content.matchAll(PLACEHOLDER_PATTERN));
+        let warnings = [];
+
+        for (let match of matches) {
+            let replacement = match[0];
+
+            try {
+                let payload = LatexToSvg.decodePayload(match[1]);
+                replacement = await LatexToSvg.renderFormula(payload.tex, payload.display);
+            } catch (error) {
+                let payload = LatexToSvg.decodePayloadSafely(match[1]);
+                let originalSource = payload ? payload.source : '';
+                replacement = LatexToSvg.escapeHtml(originalSource);
+                warnings.push({
+                    source: sourceName,
+                    formula: originalSource,
+                    message: error.message
+                });
+            }
+
+            content = content.replace(match[0], replacement);
+        }
+
+        return { content, warnings };
+    }
+
+    static async renderFormula (tex, display) {
+        let mathJax = await LatexToSvg.getMathJax();
+        let cacheKey = `${display ? 'display' : 'inline'}:${tex}`;
+
+        if (LatexToSvg.formulaCache.has(cacheKey)) {
+            return LatexToSvg.formulaCache.get(cacheKey);
+        }
+
+        mathJax.texReset();
+        let node = await mathJax.tex2svgPromise(tex, { display });
+        let svg = mathJax.startup.adaptor.serializeXML(node);
+        mathJax.texReset();
+        let mathMl = await mathJax.tex2mmlPromise(tex, { display });
+        let className = display ? 'publii-math publii-math--display' : 'publii-math publii-math--inline';
+        let style = display ? ' style="display:block;overflow-x:auto;overflow-y:hidden;text-align:center;margin:1em 0"' : '';
+        let assistiveStyle = 'position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0';
+        let assistiveMathMl = `<span class="publii-math__assistive" style="${assistiveStyle}">${mathMl}</span>`;
+        let output = `<${display ? 'div' : 'span'} class="${className}"${style}>${svg}${assistiveMathMl}</${display ? 'div' : 'span'}>`;
+
+        LatexToSvg.formulaCache.set(cacheKey, output);
+        return output;
+    }
+
+    static getMathJax () {
+        if (!LatexToSvg.mathJaxPromise) {
+            let importComponent = file => import(path.isAbsolute(file) ? pathToFileURL(file).href : file);
+
+            global.MathJax = global.MathJax || {};
+            global.MathJax.loader = Object.assign({}, global.MathJax.loader, {
+                require: importComponent
+            });
+            const MathJax = require('mathjax');
+
+            LatexToSvg.mathJaxPromise = MathJax.init({
+                loader: {
+                    load: ['input/tex', 'output/svg'],
+                    require: importComponent
+                },
+                svg: {
+                    fontCache: 'none'
+                },
+                tex: {
+                    formatError: (jax, error) => {
+                        throw error;
+                    }
+                }
+            });
+        }
+
+        return LatexToSvg.mathJaxPromise;
+    }
+
+    static decodePayload (payload) {
+        let decoded = JSON.parse(Buffer.from(payload, 'base64url').toString('utf8'));
+
+        if (
+            typeof decoded.tex !== 'string' ||
+            typeof decoded.display !== 'boolean' ||
+            typeof decoded.source !== 'string'
+        ) {
+            throw new Error('Invalid LaTeX placeholder data.');
+        }
+
+        return decoded;
+    }
+
+    static decodePayloadSafely (payload) {
+        try {
+            return LatexToSvg.decodePayload(payload);
+        } catch (error) {
+            return false;
+        }
+    }
+
+    static async findHtmlFiles (directory) {
+        let entries = await fs.readdir(directory, { withFileTypes: true });
+        let files = [];
+
+        for (let entry of entries) {
+            let entryPath = path.join(directory, entry.name);
+
+            if (entry.isDirectory()) {
+                files.push(...await LatexToSvg.findHtmlFiles(entryPath));
+            } else if (entry.isFile() && path.extname(entry.name).toLowerCase() === '.html') {
+                files.push(entryPath);
+            }
+        }
+
+        return files;
+    }
+
+    static escapeHtml (value) {
+        return value
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;')
+            .replace(/'/g, '&#039;');
+    }
+}
+
+LatexToSvg.mathJaxPromise = null;
+LatexToSvg.formulaCache = new Map();
+
+module.exports = LatexToSvg;

--- a/app/back-end/modules/render-html/text-renderers/markdown.js
+++ b/app/back-end/modules/render-html/text-renderers/markdown.js
@@ -1,4 +1,105 @@
 const marked = require('marked');
+const LatexToSvg = require('./latex');
+
+const dollarBlockPattern = /^(?: {0,3})\$\$[ \t]*(?:\r?\n([\s\S]*?)\r?\n[ \t]*\$\$[ \t]*(?:\r?\n|$)|([^\r\n]*?)\$\$[ \t]*(?:\r?\n|$))/;
+const bracketBlockPattern = /^(?: {0,3})\\\[[ \t]*(?:\r?\n([\s\S]*?)\r?\n[ \t]*\\\][ \t]*(?:\r?\n|$)|([^\r\n]*?)\\\][ \t]*(?:\r?\n|$))/;
+
+function createLatexToken (raw, tex, display, source) {
+    return {
+        type: display ? 'latexBlock' : 'latexInline',
+        raw,
+        tex,
+        display,
+        source
+    };
+}
+
+function tokenizeDollarInline (source) {
+    if (source[0] !== '$' || source[1] === '$' || !source[1] || /\s/.test(source[1])) {
+        return false;
+    }
+
+    for (let index = 1; index < source.length; index++) {
+        if (source[index] === '\n' || source[index] === '\r') {
+            return false;
+        }
+
+        if (source[index] === '\\') {
+            index++;
+            continue;
+        }
+
+        if (
+            source[index] === '$' &&
+            source[index + 1] !== '$' &&
+            !/\s/.test(source[index - 1])
+        ) {
+            let raw = source.substring(0, index + 1);
+            return createLatexToken(raw, raw.substring(1, raw.length - 1), false, raw);
+        }
+    }
+
+    return false;
+}
+
+marked.use({
+    extensions: [
+        {
+            name: 'latexBlock',
+            level: 'block',
+            start (source) {
+                let dollarIndex = source.search(/(?:^|\n) {0,3}\$\$/);
+                let bracketIndex = source.search(/(?:^|\n) {0,3}\\\[/);
+                let indexes = [dollarIndex, bracketIndex].filter(index => index > -1);
+                return indexes.length ? Math.min(...indexes) : undefined;
+            },
+            tokenizer (source) {
+                let match = dollarBlockPattern.exec(source) || bracketBlockPattern.exec(source);
+
+                if (!match) {
+                    return false;
+                }
+
+                let tex = typeof match[1] === 'string' ? match[1] : match[2];
+
+                if (!tex || !tex.trim()) {
+                    return false;
+                }
+
+                let raw = match[0];
+                let sourceText = raw.trim();
+                return createLatexToken(raw, tex, true, sourceText);
+            },
+            renderer (token) {
+                return LatexToSvg.createPlaceholder(token.tex, true, token.source);
+            }
+        },
+        {
+            name: 'latexInline',
+            level: 'inline',
+            start (source) {
+                let dollarIndex = source.indexOf('$');
+                let parenthesisIndex = source.indexOf('\\(');
+                let indexes = [dollarIndex, parenthesisIndex].filter(index => index > -1);
+                return indexes.length ? Math.min(...indexes) : undefined;
+            },
+            tokenizer (source) {
+                if (source.startsWith('\\(')) {
+                    let match = /^\\\(([^\r\n]+?)\\\)/.exec(source);
+
+                    if (match && match[1].trim()) {
+                        return createLatexToken(match[0], match[1], false, match[0]);
+                    }
+                }
+
+                return tokenizeDollarInline(source);
+            },
+            renderer (token) {
+                return LatexToSvg.createPlaceholder(token.tex, false, token.source);
+            }
+        }
+    ]
+});
 
 class MarkdownToHtml {
     static parse (inputText) {

--- a/app/back-end/modules/render-html/text-renderers/specs/latex.spec.js
+++ b/app/back-end/modules/render-html/text-renderers/specs/latex.spec.js
@@ -1,0 +1,65 @@
+const assert = require('assert');
+const fs = require('fs-extra');
+const os = require('os');
+const path = require('path');
+const LatexToSvg = require('../latex');
+
+describe('LaTeX SVG renderer', function () {
+    this.timeout(30000);
+
+    it('renders inline and display placeholders as self-contained SVG', async function () {
+        let inline = LatexToSvg.createPlaceholder('E = mc^2', false, '$E = mc^2$');
+        let display = LatexToSvg.createPlaceholder('\\begin{bmatrix}1 & 2 \\\\ 3 & 4\\end{bmatrix}', true, '$$matrix$$');
+        let result = await LatexToSvg.processContent(`<p>${inline}</p>${display}`, 'test.html');
+
+        assert.strictEqual(result.warnings.length, 0);
+        assert.ok(!result.content.includes('<publii-math'));
+        assert.match(result.content, /<mjx-container[^>]+jax="SVG"/);
+        assert.match(result.content, /<svg/);
+        assert.match(result.content, /<math[^>]+xmlns="http:\/\/www\.w3\.org\/1998\/Math\/MathML"/);
+        assert.match(result.content, /publii-math--display/);
+        assert.ok(!result.content.includes('id="MJX-'));
+        assert.ok(!result.content.includes('<script'));
+        assert.ok(!result.content.includes('cdn.jsdelivr.net'));
+    });
+
+    it('supports AMS environments and formula-local custom macros', async function () {
+        let tex = '\\newcommand{\\R}{\\mathbb{R}}\\begin{align}f &: \\R \\to \\R \\\\ f(x) &= x^2\\end{align}';
+        let placeholder = LatexToSvg.createPlaceholder(tex, true, `$$${tex}$$`);
+        let result = await LatexToSvg.processContent(placeholder, 'ams.html');
+
+        assert.strictEqual(result.warnings.length, 0);
+        assert.match(result.content, /<svg/);
+    });
+
+    it('preserves invalid formulas and reports a non-fatal warning', async function () {
+        let placeholder = LatexToSvg.createPlaceholder('\\frac{1', false, '$\\frac{1$');
+        let result = await LatexToSvg.processContent(placeholder, 'invalid.html');
+
+        assert.strictEqual(result.warnings.length, 1);
+        assert.strictEqual(result.content, '$\\frac{1$');
+        assert.match(result.warnings[0].message, /Missing|Extra|Undefined|TeX/i);
+    });
+
+    it('processes HTML files only and leaves unmarked content unchanged', async function () {
+        let tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'publii-latex-'));
+        let htmlPath = path.join(tempDir, 'index.html');
+        let xmlPath = path.join(tempDir, 'feed.xml');
+        let placeholder = LatexToSvg.createPlaceholder('x^2', false, '$x^2$');
+
+        try {
+            await fs.writeFile(htmlPath, `<p>Plain $y$ ${placeholder}</p>`, 'utf8');
+            await fs.writeFile(xmlPath, placeholder, 'utf8');
+            let warnings = await LatexToSvg.processDirectory(tempDir);
+            let html = await fs.readFile(htmlPath, 'utf8');
+            let xml = await fs.readFile(xmlPath, 'utf8');
+
+            assert.strictEqual(warnings.length, 0);
+            assert.ok(html.includes('Plain $y$'));
+            assert.match(html, /<svg/);
+            assert.ok(xml.includes('<publii-math'));
+        } finally {
+            await fs.remove(tempDir);
+        }
+    });
+});

--- a/app/back-end/modules/render-html/text-renderers/specs/markdown-latex.spec.js
+++ b/app/back-end/modules/render-html/text-renderers/specs/markdown-latex.spec.js
@@ -1,0 +1,46 @@
+const assert = require('assert');
+const MarkdownToHtml = require('../markdown');
+
+describe('Markdown LaTeX tokens', function () {
+    it('marks inline dollar and parenthesis formulas', function () {
+        let output = MarkdownToHtml.parse('Energy is $E = mc^2$ and \\(a + b\\).');
+        let placeholders = output.match(/<publii-math data-publii-latex=/g) || [];
+
+        assert.strictEqual(placeholders.length, 2);
+        assert.match(output, /Energy is <publii-math/);
+    });
+
+    it('marks single-line and multiline display formulas', function () {
+        let output = MarkdownToHtml.parse([
+            '$$E = mc^2$$',
+            '',
+            '\\[',
+            '\\begin{bmatrix}1 & 2 \\\\ 3 & 4\\end{bmatrix}',
+            '\\]'
+        ].join('\n'));
+        let placeholders = output.match(/<publii-math data-publii-latex=/g) || [];
+
+        assert.strictEqual(placeholders.length, 2);
+        assert.ok(!output.includes('<p><publii-math'));
+    });
+
+    it('does not mark escaped, currency, unmatched, code, or raw HTML formulas', function () {
+        let output = MarkdownToHtml.parse([
+            'Escaped \\$5 and currency $5 and $10 and unmatched $x.',
+            '',
+            '`$inline_code$`',
+            '',
+            '```latex',
+            '$display_code$',
+            '```',
+            '',
+            '<div>',
+            '$raw_html$',
+            '</div>'
+        ].join('\n'));
+
+        assert.ok(!output.includes('<publii-math'));
+        assert.match(output, /<code>\$inline_code\$<\/code>/);
+        assert.match(output, /<div>\n\$raw_html\$\n<\/div>/);
+    });
+});

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -39,6 +39,7 @@
         "keytar": "7.9.0",
         "ls-all": "1.1.0",
         "marked": "5.1.1",
+        "mathjax": "4.1.3",
         "mime": "3.0.0",
         "moment": "2.29.4",
         "node-sqlite3-wasm": "0.8.47",
@@ -1660,6 +1661,12 @@
       "dependencies": {
         "wasm-feature-detect": "^1.2.11"
       }
+    },
+    "node_modules/@mathjax/mathjax-newcm-font": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmmirror.com/@mathjax/mathjax-newcm-font/-/mathjax-newcm-font-4.1.3.tgz",
+      "integrity": "sha512-gzAB3dFHilHX1l5x2xUqRL+1jDQt3Fyza1DkEMVXWC4E8SvsGdlgEza47HYi2WhVcgfkvf4zgUGzuhbq3Pjlew==",
+      "license": "Apache-2.0"
     },
     "node_modules/@nodable/entities": {
       "version": "2.1.0",
@@ -4445,6 +4452,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/mathjax": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmmirror.com/mathjax/-/mathjax-4.1.3.tgz",
+      "integrity": "sha512-BN/8Pkgn7G1pIDYJqd9md+JHsE/jydSYbyOZnSdSA0WziuVO8mRxdYiWFumkVVly/8U+hm9DpIIoWuvySverzw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@mathjax/mathjax-newcm-font": "^4.1.3"
       }
     },
     "node_modules/meow": {

--- a/app/package.json
+++ b/app/package.json
@@ -55,6 +55,7 @@
     "keytar": "7.9.0",
     "ls-all": "1.1.0",
     "marked": "5.1.1",
+    "mathjax": "4.1.3",
     "mime": "3.0.0",
     "moment": "2.29.4",
     "node-sqlite3-wasm": "0.8.47",

--- a/app/src/components/post-editor/HelpPanelMarkdown.vue
+++ b/app/src/components/post-editor/HelpPanelMarkdown.vue
@@ -56,6 +56,16 @@
                     <td></td>
                 </tr>
                 <tr>
+                    <td>Inline formula</td>
+                    <td>$E = mc^2$ or \(E = mc^2\)</td>
+                    <td></td>
+                </tr>
+                <tr>
+                    <td>Display formula</td>
+                    <td>$$E = mc^2$$ or \[E = mc^2\]</td>
+                    <td></td>
+                </tr>
+                <tr>
                     <td>H1</td>
                     <td># Heading</td>
                     <td>


### PR DESCRIPTION
## Motivation & Background

Math syntax and Markdown formatting are tightly intertwined. A common workaround for adding LaTeX support to Publii sites is to inject custom HTML or JavaScript that processes formulas after the page has been generated.

This client-side post-processing approach has several limitations:

- **Pipeline ordering:** The Markdown parser may interpret underscores, asterisks, backslashes, or other characters before the math renderer receives the expression.
- **Information loss:** Recovering formulas from generated HTML is less reliable than recognizing them in the original Markdown source.
- **Runtime overhead:** Client-side rendering may require additional scripts, CDN resources, browser-side processing, and can cause layout shifts.

This PR addresses the problem at its source by recognizing math expressions during Markdown parsing, before regular Markdown transformations occur, and rendering them to SVG during site generation.

## Summary of Changes

### Native Markdown math syntax

Adds support for:

- Inline math using `$...$`
- Inline math using `\(...\)`
- Block math using `$$...$$`
- Block math using `\[...\]`

Math parsing is intentionally limited to Markdown content. TinyMCE, the block editor, and raw HTML content remain unchanged.

### Build-time SVG rendering

- Uses **MathJax 4.1.3** to render supported TeX expressions during site generation.
- Produces inline `mjx-container` and SVG markup.
- Requires no client-side MathJax runtime, CDN resources, or separate font files.
- Uses shared asynchronous initialization and formula caching to avoid repeatedly processing identical expressions.
- Supports commonly used AMS syntax, matrices, custom macros, and MathJax automatic extension loading.
- Uses the same rendering path for site previews and final exports.

### Accessibility

Assistive MathML information is preserved in the generated markup so formulas remain accessible without requiring browser-side MathJax.

### Markdown-aware delimiter handling

The parser avoids processing math delimiters inside or around:

- Escaped delimiters such as `\$`
- Common currency expressions such as `$5 and $10`
- Inline code spans
- Fenced and indented code blocks
- Raw HTML tags and blocks
- Unclosed expressions

Single-dollar inline delimiters use non-whitespace boundary rules to reduce false positives in ordinary text.

### Graceful error handling

Invalid or unsupported expressions retain their original LaTeX source and emit a clear warning without interrupting preview or static site generation.

### Documentation

The Markdown help panel now documents the supported inline and block math delimiters.

## Validation

- [x] Added targeted tests for inline, block, and multiline expressions.
- [x] Added coverage for matrices, AMS syntax, custom macros, repeated formulas, and multiple formulas on one page.
- [x] Added negative cases for escaped delimiters, currency text, unclosed expressions, code spans, code blocks, and raw HTML.
- [x] Verified that invalid expressions fall back to their original source without interrupting generation.
- [x] Verified that non-Markdown content is not converted.
- [x] Verified that generated HTML contains `mjx-container` and self-contained SVG markup.
- [x] Verified that generated HTML contains no formula placeholders, CDN references, or client-side MathJax scripts.
- [x] Completed the production Webpack build successfully.
- [x] Generated and installed the unsigned Windows x64 NSIS package successfully.
- [x] Removed the previous custom client-side HTML/JavaScript math workaround, generated and uploaded a site using the packaged application, and confirmed that inline and block formulas render correctly without external math-rendering resources.

## Scope

This implementation supports the TeX/LaTeX math syntax and extensions provided by MathJax. It does not attempt to process complete LaTeX documents, TikZ, arbitrary local packages, or TeX Live projects.